### PR TITLE
feat(elapsed): refactors elapsed time to return an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ word `if`, looking up in every schema property (AKA index):
 
 ```js
 {
-  elapsed: 184541n, // Elapsed time in nanoseconds
+  elapsed: {
+    raw: 184541,
+    formatted: '184μs',
+  },
   hits: [
     {
       id: '41013877-56',
@@ -138,7 +141,10 @@ Result:
 
 ```js
 {
-  elapsed: 172166n,
+  elapsed: {
+    raw: 172166,
+    formatted: '172μs',
+  },
   hits: [
     {
       id: '41045799-144',

--- a/packages/docs/pages/usage/search/introduction.mdx
+++ b/packages/docs/pages/usage/search/introduction.mdx
@@ -178,7 +178,10 @@ following properties:
 
 ```javascript copy
 {
-  elapsed: 181208n,
+  elapsed: {
+    raw: 181208,
+    formatted: '181μs',
+  },
   count: 2,
   hits: [
     {
@@ -207,34 +210,8 @@ following properties:
 }
 ```
 
-| Property  | Type     | Description                                                                                                       |
-| --------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| `elapsed` | `BigInt` | Time taken to execute the query.                                                                                  |
-| `hits`    | `object` | Array of results containing result score (from `0` to `1` based on relevance), Orama's ID, and original document. |
-| `count`   | `number` | Number of total results.                                                                                          |
-
-You can customize the `elapsed` property into a more readable format by using
-the `components.elapsed.format` property during the database initialization:
-
-```js
-import { create } from '@orama/orama'
-
-const db = await create({
-  schema: { ... },
-  components: {
-    elapsed: {
-      format: 'human' // defaults to 'raw'
-    }
-  }
-})
-```
-
-By setting this configuration, the `elapsed` property will be returned as a human-readable string:
-
-```js
-{
-  elapsed: '1ms',
-  count: 2,
-  hits: { ... }
-}
-```
+| Property  | Type     | Description                                                                                                         |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `elapsed` | `object` | Time taken to execute the query. <br /> Returns an object with the following shape: <br />` { raw: number, formatted: string } ` |
+| `hits`    | `object` | Array of results containing result score (from `0` to `1` based on relevance), Orama's ID, and original document.   |
+| `count`   | `number` | Number of total results.                                                                                            |

--- a/packages/docs/pages/usage/search/introduction.mdx
+++ b/packages/docs/pages/usage/search/introduction.mdx
@@ -215,3 +215,29 @@ following properties:
 | `elapsed` | `object` | Time taken to execute the query. <br /> Returns an object with the following shape: <br />` { raw: number, formatted: string } ` |
 | `hits`    | `object` | Array of results containing result score (from `0` to `1` based on relevance), Orama's ID, and original document.   |
 | `count`   | `number` | Number of total results.                                                                                            |
+
+You can always customize the behavior of the `elapsed` property by using the `formatElapsedTime` component when creating a new Orama instance:
+
+```javascript copy
+const db = await create({
+  schema: {
+    title: 'string',
+    body: 'string',
+  },
+  components: {
+    formatElapsedTime: (n: bigint) => {
+      return `custom value: ${n}`
+    }
+  }
+})
+```
+
+When performing a search operation, the `elapsed` property will now return the following value:
+
+```javascript copy
+{
+  elapsed: 'custom value: 181208', // instead of { raw: 181208, formatted: '181μs' }
+  count: 2,
+  hits: [...]
+}
+```

--- a/packages/orama/README.md
+++ b/packages/orama/README.md
@@ -102,7 +102,10 @@ word `if`, looking up in every schema property (AKA index):
 
 ```js
 {
-  elapsed: 184541n, // Elapsed time in nanoseconds
+  elapsed: {
+    raw: 184541,
+    formatted: '184μs',
+  },
   hits: [
     {
       id: '41013877-56',
@@ -138,7 +141,10 @@ Result:
 
 ```js
 {
-  elapsed: 172166n,
+  elapsed: {
+    raw: 172166,
+    formatted: '172μs',
+  },
   hits: [
     {
       id: '41045799-144',

--- a/packages/orama/src/components/defaults.ts
+++ b/packages/orama/src/components/defaults.ts
@@ -1,11 +1,14 @@
 import { createError } from '../errors.js'
-import { Document, Schema, SimpleComponents } from '../types.js'
-import { getDocumentProperties, uniqueId } from '../utils.js'
+import { Document, ElapsedTime, Schema, SimpleComponents } from '../types.js'
+import { getDocumentProperties, uniqueId, formatNanoseconds } from '../utils.js'
 
 export { getDocumentProperties } from '../utils.js'
 
-export function formatElapsedTime(n: bigint): bigint {
-  return n
+export function formatElapsedTime(n: bigint): ElapsedTime {
+  return {
+    raw: Number(n),
+    formatted: formatNanoseconds(n),
+  }
 }
 
 export function getDocumentIndexId(doc: Document): string {

--- a/packages/orama/src/methods/search.ts
+++ b/packages/orama/src/methods/search.ts
@@ -13,7 +13,7 @@ import {
   TokenMap,
   ElapsedTime,
 } from '../types.js'
-import { formatNanoseconds, getNanosecondsTime, sortTokenScorePredicate } from '../utils.js'
+import { getNanosecondsTime, sortTokenScorePredicate } from '../utils.js'
 
 const defaultBM25Params: BM25Params = {
   k: 1.2,
@@ -192,7 +192,7 @@ export async function search(orama: Orama, params: SearchParams, language?: stri
   }
 
   const searchResult: Results = {
-    elapsed: await orama.formatElapsedTime(getNanosecondsTime() - context.timeStart),
+    elapsed: (await orama.formatElapsedTime(getNanosecondsTime() - context.timeStart)) as ElapsedTime,
     hits: results.filter(Boolean),
     count: uniqueDocsArray.length,
   }

--- a/packages/orama/src/methods/search.ts
+++ b/packages/orama/src/methods/search.ts
@@ -2,8 +2,18 @@ import { prioritizeTokenScores } from '../components/algorithms.js'
 import { getFacets } from '../components/facets.js'
 import { intersectFilteredIDs } from '../components/filters.js'
 import { createError } from '../errors.js'
-import { BM25Params, IndexMap, Orama, Result, Results, SearchContext, SearchParams, TokenMap } from '../types.js'
-import { getNanosecondsTime, sortTokenScorePredicate } from '../utils.js'
+import {
+  BM25Params,
+  IndexMap,
+  Orama,
+  Result,
+  Results,
+  SearchContext,
+  SearchParams,
+  TokenMap,
+  ElapsedTime,
+} from '../types.js'
+import { formatNanoseconds, getNanosecondsTime, sortTokenScorePredicate } from '../utils.js'
 
 const defaultBM25Params: BM25Params = {
   k: 1.2,

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -194,6 +194,11 @@ export type SearchContext = {
   docsIntersection: TokenMap
 }
 
+export type ElapsedTime = {
+  raw: number
+  formatted: string
+}
+
 export type Results = {
   /**
    * The number of all the matched documents.
@@ -206,7 +211,7 @@ export type Results = {
   /**
    * The time taken to search.
    */
-  elapsed: bigint | string
+  elapsed: ElapsedTime
   /**
    * The facets results.
    */
@@ -282,7 +287,7 @@ export interface SimpleComponents<S extends Schema = Schema> {
   validateSchema(doc: Document, schema: S): SyncOrAsyncValue<boolean>
   getDocumentIndexId(doc: Document): SyncOrAsyncValue<string>
   getDocumentProperties(doc: Document, paths: string[]): SyncOrAsyncValue<Record<string, string | number | boolean>>
-  formatElapsedTime(number: bigint): SyncOrAsyncValue<bigint> | SyncOrAsyncValue<string>
+  formatElapsedTime(number: bigint): SyncOrAsyncValue<ElapsedTime> | SyncOrAsyncValue<ElapsedTime>
 }
 
 export interface SimpleOrArrayCallbackComponents {

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -287,7 +287,7 @@ export interface SimpleComponents<S extends Schema = Schema> {
   validateSchema(doc: Document, schema: S): SyncOrAsyncValue<boolean>
   getDocumentIndexId(doc: Document): SyncOrAsyncValue<string>
   getDocumentProperties(doc: Document, paths: string[]): SyncOrAsyncValue<Record<string, string | number | boolean>>
-  formatElapsedTime(number: bigint): SyncOrAsyncValue<ElapsedTime> | SyncOrAsyncValue<ElapsedTime>
+  formatElapsedTime(number: bigint): SyncOrAsyncValue<number | string | object | ElapsedTime>
 }
 
 export interface SimpleOrArrayCallbackComponents {

--- a/packages/orama/tests/elapsed.test.ts
+++ b/packages/orama/tests/elapsed.test.ts
@@ -6,14 +6,12 @@ t.test('elapsed', t => {
   t.plan(2)
 
   t.test('should correctly set elapsed time to a human-readable form', async t => {
-    t.plan(1)
+    t.plan(2)
+
     const db = await create({
       schema: {
         title: 'string',
         body: 'string',
-      },
-      components: {
-        formatElapsedTime: formatNanoseconds,
       },
     })
 
@@ -26,7 +24,8 @@ t.test('elapsed', t => {
       term: 'test',
     })
 
-    t.same(typeof results.elapsed, 'string')
+    t.same(typeof results.elapsed, 'object')
+    t.same(results.elapsed.formatted, formatNanoseconds(results.elapsed.raw))
   })
 
   t.test('should correctly set elapsed time to a bigint by default', async t => {
@@ -47,6 +46,6 @@ t.test('elapsed', t => {
       term: 'test',
     })
 
-    t.same(typeof results.elapsed, 'bigint')
+    t.same(typeof results.elapsed, 'object')
   })
 })

--- a/packages/orama/tests/elapsed.test.ts
+++ b/packages/orama/tests/elapsed.test.ts
@@ -1,17 +1,21 @@
 import t from 'tap'
 import { create, insert, search } from '../src/index.js'
-import { formatNanoseconds } from '../src/utils.js'
 
 t.test('elapsed', t => {
   t.plan(2)
 
-  t.test('should correctly set elapsed time to a human-readable form', async t => {
+  t.test('should correctly set elapsed time to a custom format', async t => {
     t.plan(2)
 
     const db = await create({
       schema: {
         title: 'string',
         body: 'string',
+      },
+      components: {
+        formatElapsedTime: (n: bigint) => {
+          return `${Number(n)}n`
+        },
       },
     })
 
@@ -24,8 +28,8 @@ t.test('elapsed', t => {
       term: 'test',
     })
 
-    t.same(typeof results.elapsed, 'object')
-    t.same(results.elapsed.formatted, formatNanoseconds(results.elapsed.raw))
+    t.same(typeof results.elapsed, 'string')
+    t.same(/(\d)n$/.test(results.elapsed as unknown as string), true)
   })
 
   t.test('should correctly set elapsed time to a bigint by default', async t => {

--- a/packages/orama/tests/main.test.ts
+++ b/packages/orama/tests/main.test.ts
@@ -342,7 +342,7 @@ t.test('orama', t => {
 
     t.ok(ex1Insert)
     t.equal(ex1Search.count, 1)
-    t.type(ex1Search.elapsed, 'bigint')
+    t.type(ex1Search.elapsed.raw, 'number')
     t.equal(ex1Search.hits[0].document.example, 'The quick, brown, fox')
   })
 


### PR DESCRIPTION
This PR introduces a small change in the returning value of the `search` function.

`search` used to return the following object:

```js
{
  elapsed: bigint,
  hits: [...],
  counts: number,
  ...
}
```

but the bigint type is not serializable in JSON and causes a lot of trouble.

This PR changes the `search` function behavior by returning an object for the `elapsed` property, with the following shape:

```js
{
  elapsed: {
    raw: 181208,            // type: number
    formatted: `181μs` // type: string
  }
}
``` 