### PR TITLE
perf(orama): Node v14 compatibility

### DIFF
--- a/packages/orama/src/utils.ts
+++ b/packages/orama/src/utils.ts
@@ -11,10 +11,11 @@ const second = BigInt(1e9)
 export const isServer = typeof window === 'undefined'
 
 export function sprintf(template: string, ...args: (string | number)[]): string {
-  return template.replaceAll(
+  return template.replace(
     /%(?:(?<position>\d+)\$)?(?<width>-?\d*\.?\d*)(?<type>[dfs])/g,
     function (...replaceArgs: Array<string | number | Record<string, string>>): string {
-      const { width: rawWidth, type, position } = replaceArgs.at(-1) as Record<string, string>
+      const groups = replaceArgs[replaceArgs.length - 1] as Record<string, string>
+      const { width: rawWidth, type, position } = groups
 
       const replacement = position ? args[Number.parseInt(position) - 1]! : args.shift()!
       const width = rawWidth === '' ? 0 : Number.parseInt(rawWidth)

--- a/packages/orama/src/utils.ts
+++ b/packages/orama/src/utils.ts
@@ -3,9 +3,6 @@ import type { Document, SearchableValue, TokenScore } from './types.js'
 const baseId = Date.now().toString().slice(5)
 let lastId = 0
 
-// Checks if `hasOwn` method is defined avoiding errors with older Node.js versions
-const hasOwn = Object.hasOwn ?? Object.prototype.hasOwnProperty.call
-
 const k = 1024
 const nano = BigInt(1e3)
 const milli = BigInt(1e6)
@@ -96,7 +93,12 @@ export function syncUniqueId(): string {
 }
 
 export function getOwnProperty<T = unknown>(object: Record<string, T>, property: string): T | undefined {
-  return hasOwn(object, property) ? object[property] : undefined
+  // Checks if `hasOwn` method is defined avoiding errors with older Node.js versions
+  if (Object.hasOwn === undefined) {
+    return Object.prototype.hasOwnProperty.call(object, property) ? object[property] : undefined;
+  }
+  
+  return Object.hasOwn(object, property) ? object[property] : undefined;
 }
 
 export function getTokenFrequency(token: string, tokens: string[]): number {

--- a/packages/orama/tests/utils.test.ts
+++ b/packages/orama/tests/utils.test.ts
@@ -39,12 +39,30 @@ t.test('utils', t => {
   t.test('should check object properties', t => {
     t.plan(2)
 
-    const myObject = {
-      foo: 'bar',
-    }
+    t.test('should return the value of the property or undefined', t => {
+      t.plan(2)
 
-    t.equal(getOwnProperty(myObject, 'foo'), 'bar')
-    t.equal(getOwnProperty(myObject, 'bar'), undefined)
+      const myObject = {
+        foo: 'bar',
+      }
+  
+      t.equal(getOwnProperty(myObject, 'foo'), 'bar')
+      t.equal(getOwnProperty(myObject, 'bar'), undefined)
+    })
+
+    t.test('should return even if the hasOwn method is not available', t => {
+      t.plan(2)
+
+      // @ts-expect-error - we are testing the fallback
+      globalThis.Object.hasOwn = undefined
+
+      const myObject = {
+        foo: 'bar',
+      }
+
+      t.equal(getOwnProperty(myObject, 'foo'), 'bar')
+      t.equal(getOwnProperty(myObject, 'bar'), undefined)
+    })
   })
 
   t.test('should get value from a nested object', async t => {


### PR DESCRIPTION
This PR aims to fix #341, making Orama compatible with Node v14.

I've changed the `hasOwn` check and added the tests for it. Also, I've replaced the `replaceAll` and `at` methods, which are not compatible with that version.
