### PR TITLE
fix: Astro plugin repository link typo

### DIFF
--- a/packages/plugin-astro/package.json
+++ b/packages/plugin-astro/package.json
@@ -9,7 +9,7 @@
     "orama",
     "search"
   ],
-  "repository": "https://github.com/oramasearch/irama",
+  "repository": "https://github.com/oramasearch/orama",
   "author": {
     "name": "Andres Correa Casablanca",
     "email": "andres.casablanca@nearform.com",


### PR DESCRIPTION
Fixes the npm package link to the github repo.