### PR TITLE
fix: repeated operation radix.ts

### DIFF
--- a/packages/orama/src/trees/radix.ts
+++ b/packages/orama/src/trees/radix.ts
@@ -131,7 +131,7 @@ export function insert(root: Node, word: string, docId: string) {
     const wordAtIndex = word.substring(i)
     const rootChildCurrentChar = root.children[currentCharacter]
 
-    if (currentCharacter in root.children) {
+    if (rootChildCurrentChar) {
       const edgeLabel = rootChildCurrentChar.subWord
       const edgeLabelLength = edgeLabel.length
 


### PR DESCRIPTION
I think `currentCharacter in root.children` is the same as checking if `const rootChildCurrentChar = root.children[currentCharacter]` is truthy