### PR TITLE
docs: fix link on plugins page

### DIFF
--- a/packages/docs/pages/plugins/index.md
+++ b/packages/docs/pages/plugins/index.md
@@ -6,4 +6,4 @@ The Orama core team is currently working on hooks, allowing the community to int
 
 That said, the Orama core team is working on some official plugins to support specific features that might not be useful for the general public. That way, you will be able to bring in only the features you really need.
 
-All the official plugins' source code is hosted under the [Orama](https://github.com/oramasearch/orama) monorepo, in the [`packages`](https://github.com/oramasearch/orama/packages) directory.
+All the official plugins' source code is hosted under the [Orama](https://github.com/oramasearch/orama) monorepo, in the [`packages`](https://github.com/oramasearch/orama/tree/main/packages) directory.


### PR DESCRIPTION
There was a wrong link on the plugins page, this PR fixes it. For issue https://github.com/oramasearch/orama/issues/370.