### PR TITLE
docs: add local development instructions in plugin-astro

### DIFF
--- a/packages/docs/pages/plugins/plugin-astro.mdx
+++ b/packages/docs/pages/plugins/plugin-astro.mdx
@@ -60,6 +60,12 @@ export default defineConfig({
 
 When running the `astro build` command, a new DB file will be persisted in the `dist/assets` directory. For the particular case of this example, it will be saved in the file `dist/assets/oramaDB_mydb.json`.
 
+### Local development
+
+Running Astro with `astro dev` does not [bundle the assets](https://docs.astro.build/en/reference/cli-reference/#astro-dev), including Orama's DBs, causing a "404 - not found" error when trying to load them.
+
+In order to use Orama in local Astro development, you can run `astro build` to build your project and then `astro preview` to [serve the built files](https://docs.astro.build/en/reference/cli-reference/#astro-preview) in the `dist/` folder.
+
 ## Loading the DB on client-side
 
 To use the generated DBs in your pages, you can include a script in your `<head>` section, as the following one:


### PR DESCRIPTION
As mentioned [on slack](https://orama-community.slack.com/archives/C0445CLH631/p1683237965615909), I added a few words about the `astro dev` limitations and `astro build` + `astro preview` solution.