### PR TITLE
feat:add support for dynamic pages to plugin-astro

### DIFF
--- a/packages/plugin-astro/src/index.ts
+++ b/packages/plugin-astro/src/index.ts
@@ -63,20 +63,12 @@ async function prepareOramaDb(
 
   // pathname is usually of the form `some/path/`, while `r.route` usually takes
   // the form `/some/path`. That's why we strip start & end slashes to compare.
+  const basePath = routes[0].distURL?.pathname?.replace(/\/$/, '').split('dist/')[0] + 'dist/'
   const pathsToBeIndexed = pages
     .filter(({ pathname }) => dbConfig.pathMatcher.test(pathname))
     .map(({ pathname }) => ({
       pathname,
-      generatedFilePath: routes.filter(r => {
-        const route = r.route.replace(/(^\/|\/$)/g, '')
-        const pathName = pathname.replace(/(^\/|\/$)/g, '')
-
-        if (dbConfig.caseSensitive) {
-          return route.toLowerCase() === pathName.toLowerCase()
-        }
-
-        return route === pathName
-      })[0]?.distURL?.pathname
+      generatedFilePath: basePath + pathname.replace(/^\//, '') + 'index.html'
     }))
     .filter(({ generatedFilePath }) => !!generatedFilePath)
 

--- a/packages/plugin-astro/test/integration.ts
+++ b/packages/plugin-astro/test/integration.ts
@@ -76,6 +76,7 @@ await test('plugin is able to generate orama DB at build time', async () => {
   // The Orama DBs have been generated
   assert.ok(existsSync(resolve(sandbox, 'dist', 'assets', 'oramaDB_animals.json')))
   assert.ok(existsSync(resolve(sandbox, 'dist', 'assets', 'oramaDB_games.json')))
+  assert.ok(existsSync(resolve(sandbox, 'dist', 'assets', 'oramaDB_dynamic.json')))
 })
 
 await test('generated DBs have indexed pages content', async () => {
@@ -90,6 +91,12 @@ await test('generated DBs have indexed pages content', async () => {
   const gamesData = JSON.parse(rawGamesData) as Schema
   const gamesDB = await createOramaDB({ schema: { _: 'string' } })
   await loadOramaDB(gamesDB, gamesData as any)
+
+  // Loading "dynamic DB"
+  const rawDynamicData = await readFile(resolve(sandbox, 'dist/assets/oramaDB_dynamic.json'), 'utf8')
+  const dynamicData = JSON.parse(rawDynamicData) as Schema
+  const dynamicDB = await createOramaDB({ schema: { _: 'string' } })
+  await loadOramaDB(dynamicDB, dynamicData as any)
 
   // Search results seem reasonable
   const catSearchResult = await search(animalsDB, { term: 'cat' })
@@ -106,6 +113,14 @@ await test('generated DBs have indexed pages content', async () => {
   // We do not have content about turtles
   const turtleSearchResult = await search(animalsDB, { term: 'turtle' })
   assert.ok(turtleSearchResult.count === 0)
+
+  // Dynamic pages are indexed
+  const dynamicTestSearchResult = await search(dynamicDB, { term: 'thiswasjustatest' })
+  assert.ok(dynamicTestSearchResult.count === 1)
+
+  // pathMatcher works on dynamic pages
+  const dynamicTestMissingSearchResult = await search(dynamicDB, { term: 'ninja' })
+  assert.ok(dynamicTestMissingSearchResult.count === 0)
 })
 
 await cleanup()

--- a/packages/plugin-astro/test/sandbox/astro.config.mjs
+++ b/packages/plugin-astro/test/sandbox/astro.config.mjs
@@ -13,8 +13,10 @@ export default defineConfig({
   integrations: [
     orama({
       animals: { pathMatcher: /animals_.+$/ },
-      games: { pathMatcher: /games_.+$/ }
+      games: { pathMatcher: /games_.+$/ },
+      dynamic: { pathMatcher: /blog\/inner-path\/article(.*)$/ }
     })
   ],
-  trailingSlash: 'always'
+  trailingSlash: 'always',
+  output: 'static'
 })

--- a/packages/plugin-astro/test/sandbox/src/content/posts/article.md
+++ b/packages/plugin-astro/test/sandbox/src/content/posts/article.md
@@ -1,0 +1,5 @@
+---
+title: 'A cool article'
+---
+
+This is some text ready to be parsed by the plugin, which will find the word thiswasjustatest and index it.

--- a/packages/plugin-astro/test/sandbox/src/content/posts/foobar.md
+++ b/packages/plugin-astro/test/sandbox/src/content/posts/foobar.md
@@ -1,0 +1,5 @@
+---
+title: 'A terrible article'
+---
+
+This ninja text will not get indexed by the plugin because of the pathMatcher excluding this.

--- a/packages/plugin-astro/test/sandbox/src/content/posts/foobar2.md
+++ b/packages/plugin-astro/test/sandbox/src/content/posts/foobar2.md
@@ -1,0 +1,5 @@
+---
+title: 'A terrible article 2'
+---
+
+This ninja text will not get indexed by the plugin because of the pathMatcher excluding this.

--- a/packages/plugin-astro/test/sandbox/src/pages/[...blog]/[...inner]/index.astro
+++ b/packages/plugin-astro/test/sandbox/src/pages/[...blog]/[...inner]/index.astro
@@ -1,0 +1,23 @@
+---
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection("posts");
+
+  return (posts).map((post: any) => {
+    return {
+      params: {
+        blog: "blog",
+        inner: "inner-path/" + post.slug
+      },
+      props: { post },
+    };
+  });
+}
+
+const { post } = Astro.props
+---
+
+<div class="content">
+  {post.body}
+</div>


### PR DESCRIPTION
This PR fixes #366 

After all the investigation reported in the issue, I noticed that static pages are working fine but dynamic routes are not provided by Astro after the build.

With this PR I grab the path of the dist folder by taking the first route, then I compose the path of all other pages from that.

To validate if it works I added three dynamic pages and a new database with a pattern matcher in the sandbox project. Only the page matching the pattern is indexed, as expected. I also expanded the integration tests and they're still passing.


If this makes some kind of sense I'm happy to discuss it here or on Slack!
I'll be really happy to be able to use Orama on my Astro blog with dynamic pages :D