### PR TITLE
fix: handle pages that are not generated inside a folder

### DIFF
--- a/packages/plugin-astro/test/integration.ts
+++ b/packages/plugin-astro/test/integration.ts
@@ -98,6 +98,12 @@ await test('generated DBs have indexed pages content', async () => {
   const dynamicDB = await createOramaDB({ schema: { _: 'string' } })
   await loadOramaDB(dynamicDB, dynamicData as any)
 
+  // Loading "allSite DB"
+  const rawAllSiteData = await readFile(resolve(sandbox, 'dist/assets/oramaDB_allSite.json'), 'utf8')
+  const allSiteData = JSON.parse(rawAllSiteData) as Schema
+  const allSiteDB = await createOramaDB({ schema: { _: 'string' } })
+  await loadOramaDB(allSiteDB, allSiteData as any)
+
   // Search results seem reasonable
   const catSearchResult = await search(animalsDB, { term: 'cat' })
   assert.ok(catSearchResult.count === 1)

--- a/packages/plugin-astro/test/sandbox/astro.config.mjs
+++ b/packages/plugin-astro/test/sandbox/astro.config.mjs
@@ -14,9 +14,9 @@ export default defineConfig({
     orama({
       animals: { pathMatcher: /animals_.+$/ },
       games: { pathMatcher: /games_.+$/ },
-      dynamic: { pathMatcher: /blog\/inner-path\/article(.*)$/ }
+      dynamic: { pathMatcher: /blog\/inner-path\/article(.*)$/ },
+      allSite: { pathMatcher: /.*/ }
     })
   ],
-  trailingSlash: 'always',
-  output: 'static'
+  trailingSlash: 'always'
 })

--- a/packages/plugin-astro/test/sandbox/src/pages/404.astro
+++ b/packages/plugin-astro/test/sandbox/src/pages/404.astro
@@ -1,0 +1,1 @@
+Page not found!

--- a/packages/plugin-astro/test/sandbox/src/pages/nested/page.astro
+++ b/packages/plugin-astro/test/sandbox/src/pages/nested/page.astro
@@ -1,0 +1,1 @@
+This is a nested page


### PR DESCRIPTION
It's me again! :)

After installing the plugin on my blog I noticed in some cases astro does not generate pages as `dist/path/to/404/index.html` but directly `dist/404.html` which wasn't covered in #375.

I noticed this happened with `404.astro` as it becomes `404.html` while `a404.astro `becomes `a404/index.html`

![image](https://github.com/oramasearch/orama/assets/7253929/83bf5934-d26d-4ee7-8a2d-aa04f054ae50)

---

I improved the path handling in the script to detect these cases and properly handle them
As usual, I added a test, this time with a permissive matcher to make sure 404 is handled and no errors are thrown.