### PR TITLE
Rework *Multiple methods

### DIFF
--- a/packages/docs/pages/usage/remove.mdx
+++ b/packages/docs/pages/usage/remove.mdx
@@ -90,3 +90,5 @@ const docs = [
 const ids = await insertMultiple(movieDB, docs, 500);
 await removeMultiple(movieDB, ids, 500);
 ```
+
+The function returns the number of the removed documents.

--- a/packages/orama/src/methods/remove.ts
+++ b/packages/orama/src/methods/remove.ts
@@ -1,6 +1,5 @@
 import { runMultipleHook, runSingleHook } from '../components/hooks.js'
 import { trackRemoval } from '../components/sync-blocking-checker.js'
-import { createError } from '../errors.js'
 import { Orama } from '../types.js'
 
 export async function remove(orama: Orama, id: string, language?: string, skipHooks?: boolean): Promise<boolean> {
@@ -9,7 +8,7 @@ export async function remove(orama: Orama, id: string, language?: string, skipHo
 
   const doc = await orama.documentsStore.get(docs, id)
   if (!doc) {
-    throw createError('DOCUMENT_DOES_NOT_EXIST', id)
+    return false
   }
 
   const docsCount = await orama.documentsStore.count(docs)
@@ -51,8 +50,8 @@ export async function removeMultiple(
   batchSize?: number,
   language?: string,
   skipHooks?: boolean,
-): Promise<boolean> {
-  let result = true
+): Promise<number> {
+  let result = 0
 
   if (!batchSize) {
     batchSize = 1000
@@ -74,8 +73,8 @@ export async function removeMultiple(
 
       for (const doc of batch) {
         try {
-          if (!(await remove(orama, doc, language, skipHooks))) {
-            result = false
+          if (await remove(orama, doc, language, skipHooks)) {
+            result++
           }
         } catch (err) {
           reject(err)

--- a/packages/orama/tests/remove.test.ts
+++ b/packages/orama/tests/remove.test.ts
@@ -1,6 +1,6 @@
 import t from 'tap'
 import { Index } from '../src/components/index.js'
-import { remove, create, insert, getByID, search, Orama, SearchParams, removeMultiple } from '../src/index.js'
+import { remove, create, insert, getByID, search, Orama, SearchParams, removeMultiple, count } from '../src/index.js'
 
 t.test('remove method', t => {
   t.test('removes the given document', async t => {
@@ -155,7 +155,7 @@ t.test('remove method', t => {
 
   t.test('should throw an error on unknown document', async t => {
     const [db] = await createSimpleDB()
-    await t.rejects(() => remove(db, 'unknown index id'))
+    t.equal(await remove(db, 'unknown index id'), false)
     t.end()
   })
 
@@ -170,6 +170,8 @@ t.test('removeMultiple method', t => {
 
     t.ok(await getByID(db, id3))
     t.ok(await getByID(db, id4))
+
+    t.equal(await count(db), 2)
 
     t.end()
   })
@@ -187,6 +189,26 @@ t.test('removeMultiple method', t => {
     clearInterval(intervalId)
 
     t.equal(count, 5)
+
+    t.end()
+  })
+
+  t.test('should throw an error on error', async t => {
+    const db = await create({
+      schema: {
+        name: 'string',
+      },
+      components: {
+        beforeMultipleRemove: function() {
+          throw new Error('Kaboom')
+        }
+      },
+    })
+    const id1 = await insert(db, { name: 'coffee' })
+
+    await t.rejects(removeMultiple(db, [id1]), {
+      message: 'Kaboom'
+    })
 
     t.end()
   })


### PR DESCRIPTION
This PR introduces those changes:
- `remove` method returns false if the document is not found
- `removeAll` returns the number of the removed documents
- `updateMany` doesn't remove the documents if some of them are invalid
