### PR TITLE
perf: skip get balance factor

### DIFF
--- a/packages/orama/src/trees/avl.ts
+++ b/packages/orama/src/trees/avl.ts
@@ -6,11 +6,6 @@ export type Node<K, V> = {
   height: number
 }
 
-type StackNode<K, V> = {
-  node: Node<K, V>,
-  checkedChildren: boolean
-};
-
 const BALANCE_STATE = {
   UNBALANCED_RIGHT: -2,
   SLIGHTLY_UNBALANCED_RIGHT: -1,

--- a/packages/orama/src/trees/avl.ts
+++ b/packages/orama/src/trees/avl.ts
@@ -12,28 +12,11 @@ type StackNode<K, V> = {
 };
 
 const BALANCE_STATE = {
-  UNBALANCED_RIGHT: 1,
-  SLIGHTLY_UNBALANCED_RIGHT: 2,
-  BALANCED: 3,
-  SLIGHTLY_UNBALANCED_LEFT: 4,
-  UNBALANCED_LEFT: 5,
-}
-
-function getBalanceFactor<K, V>(node: Node<K, V>): number {
-  const heightDifference = getHeight(node.left) - getHeight(node.right)
-
-  switch (heightDifference) {
-    case -2:
-      return BALANCE_STATE.UNBALANCED_RIGHT
-    case -1:
-      return BALANCE_STATE.SLIGHTLY_UNBALANCED_RIGHT
-    case 1:
-      return BALANCE_STATE.SLIGHTLY_UNBALANCED_LEFT
-    case 2:
-      return BALANCE_STATE.UNBALANCED_LEFT
-    default:
-      return BALANCE_STATE.BALANCED
-  }
+  UNBALANCED_RIGHT: -2,
+  SLIGHTLY_UNBALANCED_RIGHT: -1,
+  BALANCED: 0,
+  SLIGHTLY_UNBALANCED_LEFT: 1,
+  UNBALANCED_LEFT: 2,
 }
 
 function getHeight<K, V>(node: Node<K, V> | null): number {
@@ -263,8 +246,8 @@ export function insert<K, V>(root: Node<K, V>, key: K, value: V): Node<K, V> {
   current = newNode;
 
   while (parent) {
-    const balanceFactor = getBalanceFactor(parent);
-    
+    const balanceFactor = getHeight(parent.left) - getHeight(parent.right)
+
     if (balanceFactor === BALANCE_STATE.UNBALANCED_LEFT) {
         if (key < (parent.left as Node<K, V>).key) {
             parent = rotateRight(parent);


### PR DESCRIPTION
Since `getBalanceFactor` is used in one place, don't have the necessity of having a function with switch statement, just get the diff of the height and then compare directly.

I also removed the unused StackNode type.