### PR TITLE
fix: fix the build of Astro Plugin on Windows OS

### DIFF
--- a/packages/plugin-astro/src/index.ts
+++ b/packages/plugin-astro/src/index.ts
@@ -65,16 +65,16 @@ async function prepareOramaDb(
   })
 
   // All routes are in the same folder, we can use the first one to get the basePath
-  const basePath = routes[0].distURL?.pathname?.replace(/\/$/, '').split('dist/')[0] + 'dist/'
+  const basePath = (routes[0].distURL?.pathname?.replace(/\/$/, '').split('dist/')[0] + 'dist/').slice(isWindows ? 1 : 0);
   const pathsToBeIndexed = pages
     .filter(({ pathname }) => dbConfig.pathMatcher.test(pathname))
     .map(({ pathname }) => {
       // Some pages like 404 are generated as 404.html while others are usually pageName/index.html
-      const matchingPathname = routes.find(r => r.distURL?.pathname.endsWith(pathname.replace(/\/$/, '') + '.html'))
-        ?.distURL?.pathname
+      const matchingPathname = (routes.find(r => r.distURL?.pathname.endsWith(pathname.replace(/\/$/, '') + '.html'))
+        ?.distURL?.pathname)?.slice(isWindows ? 1 : 0);
       return {
         pathname,
-        generatedFilePath: matchingPathname ?? `${basePath}${pathname}index.html`
+        generatedFilePath: matchingPathname ?? `${basePath}${pathname}${isWindows ? "/" : "\\"}index.html`
       }
     })
     .filter(({ generatedFilePath }) => !!generatedFilePath)


### PR DESCRIPTION
After trying to run a build of my Astro Blog with the Orama Plugin I noticed an error.
It's because some directories aren't compliant with Windows Os.

I also fixed the fact that the plugin was looking for files with wrong names like `mobile-appindex.html` instead of `mobile-app/index.html`

After the fix the build complete without any other issue.

This closes issue #405 