### PR TITLE
perf: remove unused properties from radix

### DIFF
--- a/packages/orama/src/trees/radix.ts
+++ b/packages/orama/src/trees/radix.ts
@@ -1,12 +1,9 @@
-import { syncBoundedLevenshtein } from '../components/levenshtein.js'
-import { Nullable } from '../types.js'
-import { getOwnProperty, syncUniqueId } from '../utils.js'
+import { syncBoundedLevenshtein } from "../components/levenshtein.js";
+import { getOwnProperty } from "../utils.js";
 
 export interface Node {
-  id: string
   key: string
   subWord: string
-  parent: Nullable<string>
   children: Record<string, Node>
   docs: string[]
   end: boolean
@@ -29,7 +26,6 @@ function serialize(this: Node): object {
 }
 
 function updateParent(node: Node, parent: Node): void {
-  node.parent = parent.id
   node.word = parent.word + node.subWord
 }
 
@@ -111,10 +107,8 @@ function getCommonPrefix(a: string, b: string) {
 
 export function create(end = false, subWord = '', key = ''): Node {
   const node = {
-    id: syncUniqueId(),
     key,
     subWord,
-    parent: null,
     children: {},
     docs: [],
     end,

--- a/packages/orama/src/utils.ts
+++ b/packages/orama/src/utils.ts
@@ -88,11 +88,6 @@ export async function uniqueId(): Promise<string> {
   return `${baseId}-${lastId++}`
 }
 
-// This is only used internally, keep in sync with the previous one
-export function syncUniqueId(): string {
-  return `${baseId}-${lastId++}`
-}
-
 export function getOwnProperty<T = unknown>(object: Record<string, T>, property: string): T | undefined {
   // Checks if `hasOwn` method is defined avoiding errors with older Node.js versions
   if (Object.hasOwn === undefined) {

--- a/packages/orama/tests/snapshots/events.json
+++ b/packages/orama/tests/snapshots/events.json
@@ -6,51 +6,12 @@
         "id": "",
         "score": 4.744426329679039,
         "document": {
-          "date": "1809/03/13",
-          "description": "Peninsular War",
-          "granularity": "year",
-          "categories": {
-            "first": "January/March",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.744426329679039,
-        "document": {
-          "date": "1867/12/02",
-          "description": "Paraguayan War.",
-          "granularity": "year",
-          "categories": {
-            "first": "Ongoing",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.744426329679039,
-        "document": {
           "date": "-89",
           "description": "Social War:",
           "granularity": "year",
           "categories": {
             "first": "By place",
             "second": "Roman Republic"
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.744426329679039,
-        "document": {
-          "date": "1914/12/24",
-          "description": " World War I:",
-          "granularity": "year",
-          "categories": {
-            "first": "December",
-            "second": ""
           }
         }
       },
@@ -131,12 +92,7 @@
             "second": "Roman Republic"
           }
         }
-      }
-    ]
-  },
-  "should perform paginate search-page-2": {
-    "count": 2357,
-    "hits": [
+      },
       {
         "id": "",
         "score": 4.744426329679039,
@@ -167,11 +123,216 @@
         "id": "",
         "score": 4.744426329679039,
         "document": {
+          "date": "1809/03/13",
+          "description": "Peninsular War",
+          "granularity": "year",
+          "categories": {
+            "first": "January/March",
+            "second": ""
+          }
+        }
+      }
+    ]
+  },
+  "should perform paginate search-page-2": {
+    "count": 2357,
+    "hits": [
+      {
+        "id": "",
+        "score": 4.744426329679039,
+        "document": {
+          "date": "1867/12/02",
+          "description": "Paraguayan War.",
+          "granularity": "year",
+          "categories": {
+            "first": "Ongoing",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.744426329679039,
+        "document": {
+          "date": "1914/12/24",
+          "description": " World War I:",
+          "granularity": "year",
+          "categories": {
+            "first": "December",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.744426329679039,
+        "document": {
           "date": "1950/02/14",
           "description": " Cold War:",
           "granularity": "year",
           "categories": {
             "first": "February",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "-86",
+          "description": "First Mithridatic War",
+          "granularity": "year",
+          "categories": {
+            "first": "By place",
+            "second": "Roman Republic"
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1447/07/15",
+          "description": "The Albanian-Venetian War of 1447-1448.",
+          "granularity": "year",
+          "categories": {
+            "first": "Date unknown",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1470/10/30",
+          "description": "Start of the Anglo-Hanseatic War.",
+          "granularity": "year",
+          "categories": {
+            "first": "Date unknown",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1522/12/20",
+          "description": "The Habsburg-Valois Wars begin.",
+          "granularity": "year",
+          "categories": {
+            "first": "Date unknown",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1558/01/22",
+          "description": " Beginning of the Livonian War.",
+          "granularity": "year",
+          "categories": {
+            "first": "January/June",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1728/10/20",
+          "description": "The Meerkat–Mongoose war.",
+          "granularity": "year",
+          "categories": {
+            "first": "In fiction",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1830/12/20",
+          "description": "The Java War ends.",
+          "granularity": "year",
+          "categories": {
+            "first": "Date unknown",
+            "second": ""
+          }
+        }
+      }
+    ]
+  },
+  "should perform paginate search-page-3": {
+    "count": 2357,
+    "hits": [
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1857/04/04",
+          "description": " End of the Anglo-Persian War.",
+          "granularity": "year",
+          "categories": {
+            "first": "April/June",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1861/04/27",
+          "description": " American Civil War:",
+          "granularity": "year",
+          "categories": {
+            "first": "April/June",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1879/01/11",
+          "description": " The Anglo-Zulu War begins.",
+          "granularity": "year",
+          "categories": {
+            "first": "January/March",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1919/02/14",
+          "description": " The Polish-Soviet War begins.",
+          "granularity": "year",
+          "categories": {
+            "first": "February",
+            "second": ""
+          }
+        }
+      },
+      {
+        "id": "",
+        "score": 4.087300377720357,
+        "document": {
+          "date": "1939/03/23",
+          "description": " The Slovak-Hungarian War begins.",
+          "granularity": "year",
+          "categories": {
+            "first": "March",
             "second": ""
           }
         }
@@ -238,167 +399,6 @@
           "categories": {
             "first": "By place",
             "second": "Europe"
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1043/10/31",
-          "description": "Rus'-Byzantine War (1043).",
-          "granularity": "year",
-          "categories": {
-            "first": "",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1447/07/15",
-          "description": "The Albanian-Venetian War of 1447-1448.",
-          "granularity": "year",
-          "categories": {
-            "first": "Date unknown",
-            "second": ""
-          }
-        }
-      }
-    ]
-  },
-  "should perform paginate search-page-3": {
-    "count": 2357,
-    "hits": [
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1470/10/30",
-          "description": "Start of the Anglo-Hanseatic War.",
-          "granularity": "year",
-          "categories": {
-            "first": "Date unknown",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1522/12/20",
-          "description": "The Habsburg-Valois Wars begin.",
-          "granularity": "year",
-          "categories": {
-            "first": "Date unknown",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1558/01/22",
-          "description": " Beginning of the Livonian War.",
-          "granularity": "year",
-          "categories": {
-            "first": "January/June",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1728/10/20",
-          "description": "The Meerkat–Mongoose war.",
-          "granularity": "year",
-          "categories": {
-            "first": "In fiction",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1830/12/20",
-          "description": "The Java War ends.",
-          "granularity": "year",
-          "categories": {
-            "first": "Date unknown",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1857/04/04",
-          "description": " End of the Anglo-Persian War.",
-          "granularity": "year",
-          "categories": {
-            "first": "April/June",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1861/04/27",
-          "description": " American Civil War:",
-          "granularity": "year",
-          "categories": {
-            "first": "April/June",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "-113",
-          "description": "War between the Celtiberians and the Romans.",
-          "granularity": "year",
-          "categories": {
-            "first": "By place",
-            "second": "Roman Republic"
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "1879/01/11",
-          "description": " The Anglo-Zulu War begins.",
-          "granularity": "year",
-          "categories": {
-            "first": "January/March",
-            "second": ""
-          }
-        }
-      },
-      {
-        "id": "",
-        "score": 4.087300377720357,
-        "document": {
-          "date": "-86",
-          "description": "First Mithridatic War",
-          "granularity": "year",
-          "categories": {
-            "first": "By place",
-            "second": "Roman Republic"
           }
         }
       }


### PR DESCRIPTION
There is currently no reason for `radix` to have an `id` or `parent` property, so can we remove it?

This breaks a test in `dataset.test.ts`, but breaks the order of the `snapshot`, from what I can see the documents are just being returned in a different order than expected.