### PR TITLE
feat: first draft of id shortener

### DIFF
--- a/packages/orama/src/id-shortener.ts
+++ b/packages/orama/src/id-shortener.ts
@@ -1,6 +1,6 @@
 import { IdStore } from './types.js'
 
-const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()'
+const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+,-./:;<=>?@[]^_`{|}~';
 
 export function generateShortId(last: string) {
   if (last === '') {
@@ -21,8 +21,10 @@ export function generateShortId(last: string) {
 }
 
 export function generateUniqueShortId(db: IdStore, original: string): string {
-  if (Object.hasOwn(db.originalToShort, original)) {
-    return db.originalToShort[original]
+
+  const existing = db.originalToShort[original]
+  if (existing) {
+    return existing
   }
 
   const newId = generateShortId(db.lastShort)

--- a/packages/orama/src/id-shortener.ts
+++ b/packages/orama/src/id-shortener.ts
@@ -1,0 +1,54 @@
+import { IdStore } from './types.js'
+
+const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()'
+
+export function generateShortId(last: string) {
+  if (last === '') {
+    return characters[0]
+  }
+
+  const lastGeneratedIdLastIndex = last.length - 1
+
+  const lastChar = last[lastGeneratedIdLastIndex]
+
+  const charIndex = characters.indexOf(lastChar)
+
+  if (charIndex === characters.length - 1) {
+    return last + characters[0]
+  }
+
+  return last.substring(0, lastGeneratedIdLastIndex) + characters[charIndex + 1]
+}
+
+export function generateUniqueShortId(db: IdStore, original: string): string {
+  if (Object.hasOwn(db.originalToShort, original)) {
+    return db.originalToShort[original]
+  }
+
+  const newId = generateShortId(db.lastShort)
+
+  db.originalToShort[original] = newId
+
+  db.lastShort = newId
+
+  db.shortToOriginal[newId] = original
+
+  return newId
+}
+
+export function getOriginalId(db: IdStore, id: string) {
+  return db.shortToOriginal[id]
+}
+
+export function getGeneratedId(db: IdStore, id: string) {
+  return db.originalToShort[id]
+}
+
+export function createNewIdDatabase() {
+  return {
+    lastShort: '',
+    shortToOriginal: {},
+    originalToShort: {},
+  }
+}
+

--- a/packages/orama/src/id-shortener.ts
+++ b/packages/orama/src/id-shortener.ts
@@ -6,11 +6,8 @@ export function generateShortId(last: string) {
   if (last === '') {
     return characters[0]
   }
-
   const lastGeneratedIdLastIndex = last.length - 1
-
   const lastChar = last[lastGeneratedIdLastIndex]
-
   const charIndex = characters.indexOf(lastChar)
 
   if (charIndex === characters.length - 1) {
@@ -28,11 +25,8 @@ export function generateUniqueShortId(db: IdStore, original: string): string {
   }
 
   const newId = generateShortId(db.lastShort)
-
   db.originalToShort[original] = newId
-
   db.lastShort = newId
-
   db.shortToOriginal[newId] = original
 
   return newId

--- a/packages/orama/src/methods/create.ts
+++ b/packages/orama/src/methods/create.ts
@@ -24,6 +24,7 @@ import {
   SingleOrArray,
 } from '../types.js'
 import { createSorter } from '../components/sorter.js'
+import { createNewIdDatabase } from '../id-shortener.js'
 
 interface CreateArguments<P extends ProvidedTypes> {
   schema: Schema
@@ -174,6 +175,7 @@ export async function create<P extends ProvidedTypes>({
     afterMultipleUpdate,
     formatElapsedTime,
     id,
+    idStore: createNewIdDatabase(),
   } as Orama
 
   orama.data = {

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -593,6 +593,12 @@ interface Data<I extends OpaqueIndex, D extends OpaqueDocumentStore, S extends O
   sorting: S
 }
 
+export type IdStore = {
+  lastShort: string
+  originalToShort: Record<string, string>
+  shortToOriginal: Record<string, string>
+}
+
 type Internals<P extends ProvidedTypes> = {
   schema: P['Schema']
   tokenizer: Tokenizer
@@ -603,6 +609,7 @@ type Internals<P extends ProvidedTypes> = {
   caches: Record<string, unknown>
   [kInsertions]: number | undefined
   [kRemovals]: number | undefined
+  idStore: IdStore
 }
 
 type OramaID = {

--- a/packages/orama/tests/id-shortener.test.ts
+++ b/packages/orama/tests/id-shortener.test.ts
@@ -1,0 +1,63 @@
+import t from 'tap'
+import {
+  generateShortId,
+  generateUniqueShortId,
+  getOriginalId,
+  getGeneratedId,
+  createNewIdDatabase,
+} from '../src/id-shortener.js'
+
+t.test('follow sequence', t => {
+  t.plan(3)
+  t.equal(generateShortId(''), 'A')
+  t.equal(generateShortId('A'), 'B')
+  t.equal(generateShortId(')'), ')A')
+})
+
+t.test('create and retrieve key', t => {
+  t.plan(6)
+  const idDatabase = createNewIdDatabase()
+  const first = 'foobar'
+  const firstKey = generateUniqueShortId(idDatabase, first)
+  t.equal(firstKey, 'A')
+  t.equal(getOriginalId(idDatabase, firstKey), first)
+
+  const second = 'hello'
+  const secondKey = generateUniqueShortId(idDatabase, second)
+  t.equal(secondKey, 'B')
+  t.equal(getOriginalId(idDatabase, secondKey), second)
+
+  t.equal('A', getGeneratedId(idDatabase, first))
+  t.equal('B', getGeneratedId(idDatabase, second))
+})
+
+t.test('massive insertion', t => {
+  t.plan(1)
+  const idDatabase = createNewIdDatabase()
+  const generatedIds: string[] = []
+  for (let i = 0; i < 1000; i++) {
+    const generatedId = generateUniqueShortId(idDatabase, i.toString())
+    generatedIds.push(generatedId)
+  }
+
+  const generatedIdsLength = generatedIds.length
+
+  const uniqueIdsSize = new Set(generatedIds).size
+
+  t.equal(generatedIdsLength, uniqueIdsSize)
+})
+
+t.test('generate same key', t => {
+  t.plan(5)
+  const idDatabase = createNewIdDatabase()
+  const originalId = 'foobar'
+  const firstKey = generateUniqueShortId(idDatabase, originalId)
+  t.equal(firstKey, 'A')
+  t.equal(getOriginalId(idDatabase, firstKey), originalId)
+
+  const secondKey = generateUniqueShortId(idDatabase, originalId)
+  t.equal(secondKey, firstKey)
+  t.equal(getOriginalId(idDatabase, secondKey), originalId)
+
+  t.equal('A', getGeneratedId(idDatabase, originalId))
+})

--- a/packages/orama/tests/id-shortener.test.ts
+++ b/packages/orama/tests/id-shortener.test.ts
@@ -11,7 +11,7 @@ t.test('follow sequence', t => {
   t.plan(3)
   t.equal(generateShortId(''), 'A')
   t.equal(generateShortId('A'), 'B')
-  t.equal(generateShortId(')'), ')A')
+  t.equal(generateShortId('~'), '~A')
 })
 
 t.test('create and retrieve key', t => {


### PR DESCRIPTION
first possible implementation of id-shortener:
the data structure is 
`
export type IdStore = {
  lastShort: string
  originalToShort: Record<string, string>
  shortToOriginal: Record<string, string>
}`

it will start generating ids from `A, B, C` saving the reference generated to original and other way around, so every id is stored 2 times . I chose this solution because is very easy to serialize, but I'm sure there might be something way better.
If this idea is valid I'll work on the integration with the tree

