### PR TITLE
Implement enum type

### DIFF
--- a/packages/docs/pages/index.mdx
+++ b/packages/docs/pages/index.mdx
@@ -13,7 +13,7 @@ Orama is a fast, batteries-included, full-text and vector search engine entirely
   title="YouTube video player"
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowfullScreen>
+  allowFullScreen>
 </iframe>
 <br />
 
@@ -93,6 +93,40 @@ Or import it directly in a browser module:
   </body>
 </html>
 ```
+
+## Basic usage
+
+```ts copy
+import { create, search, insert } from '@orama/orama'
+
+const db = await create({
+  schema: {
+    name: 'string',
+    description: 'string',
+    price: 'number',
+    meta: {
+      rating: 'number',
+    },
+  },
+})
+
+await insert(db, {
+  name: 'Wireless Headphones',
+  description: 'Experience immersive sound quality with these noise-cancelling wireless headphones.',
+  price: 99.99,
+  meta: {
+    rating: 4.5,
+  },
+})
+
+const searchResult = await search(db, {
+  term: 'headphones',
+})
+
+console.log(searchResult.hits.map((hit) => hit.document))
+```
+
+For more information, check out the [Usage](/usage/create) section.
 
 # CommonJS Imports
 

--- a/packages/docs/pages/usage/create.mdx
+++ b/packages/docs/pages/usage/create.mdx
@@ -18,7 +18,7 @@ Orama supports the following types:
 | `string`         | A string of characters.                                                     | `'Hello world'`                                                             |
 | `number`         | A numeric value, either float or integer.                                   | `42`                                                                        |
 | `boolean`        | A boolean value.                                                            | `true`                                                                      |
-| `enum`           | An enum value.   (since version 1.3.0)                                      | `'drama'`                                                                   |
+| `enum`           | An enum value.                                                              | `'drama'`                                                                   |
 | `string[]`       | An array of strings.                                                        | `['red', 'green', 'blue']`                                                  |
 | `number[]`       | An array of numbers.                                                        | `[42, 91, 28.5]`                                                            |
 | `boolean[]`      | An array of booleans.                                                       | `[true, false, false]`                                                      |

--- a/packages/docs/pages/usage/create.mdx
+++ b/packages/docs/pages/usage/create.mdx
@@ -4,12 +4,7 @@ import { Callout } from 'nextra-theme-docs'
 
 We can create a new instance (from now on database) with an **indexing `schema`**.<br/>
 The schema represents **the searchable properties** of the document to be inserted.
-
 Not all properties need to be indexed, but only those that we want to be able to search for.
-
-Adding a property to the schema will make it searchable, but it will also increase the size of the database and overall insertion and search times.
-
-Therefore, you should only index the properties that you need to search for.
 
 If you want to learn more and see real-world examples, check out [this blog post](https://oramasearch.com/blog/optimizing-orama-schema-optimization) we wrote about schema optimization.
 
@@ -23,10 +18,11 @@ Orama supports the following types:
 | `string`         | A string of characters.                                                     | `'Hello world'`                                                             |
 | `number`         | A numeric value, either float or integer.                                   | `42`                                                                        |
 | `boolean`        | A boolean value.                                                            | `true`                                                                      |
+| `enum`           | An enum value.   (since version 1.3.0)                                      | `'drama'`                                                                   |
 | `string[]`       | An array of strings.                                                        | `['red', 'green', 'blue']`                                                  |
 | `number[]`       | An array of numbers.                                                        | `[42, 91, 28.5]`                                                            |
 | `boolean[]`      | An array of booleans.                                                       | `[true, false, false]`                                                      |
-| `vector[<size>]` | A vector of numbers to perform vector search on.                            | `[0.403, 0.192, 0.830]`                                                               |
+| `vector[<size>]` | A vector of numbers to perform vector search on.                            | `[0.403, 0.192, 0.830]`                                                     |
 
 A database can be as simple as:
 
@@ -74,6 +70,18 @@ const movieDB = await create({
     isFavorite: 'boolean',
   },
 })
+
+await insert(db, {
+  title: 'The Godfather',
+  plot: 'The aging patriarch of an organized crime dynasty transfers control of his clandestine empire to his reluctant son.',
+  cast: {
+    director: 'Francis Ford Coppola',
+    leading: 'Marlon Brando',
+    supporting: ['Al Pacino', 'James Caan', 'Robert Duvall'],
+  },
+  year: 1972,
+  isFavorite: true,
+})
 ```
 
 ## Vector properties
@@ -85,19 +93,23 @@ To run vector queries, you first need to initialize a vector property in the sch
 const db = await create({
   schema: {
     title: 'string',
-    embedding: 'vector[384]',
+    embedding: 'vector[10]', // replace 10 with the appropriate size of your vector
   }
+})
+
+await insert(db, {
+  title: 'The Godfather',
+  embedding: [-0.8469661901208547, 0.6762289692745016, 0.3294302068627739, -0.9269241187762711, -0.8340635986042049, -0.9940330715457502, -0.46761552816396046, 0.2818135926099674, -0.5812061227183709, 0.6443446315273054],
 })
 ```
 
 Please note that the size of the vector **must** be specified in the schema. \
 The size of the vector is the number of elements that the vector contains, so make sure to specify the correct size, as performing search on vectors of different sizes will result in unpredictable and mostly wrong results.
+For performance reasons, we recommend using one vector property per database, even though it's possible to have multiple vector properties in the same Orama instance.
 
 If you're using vector properties to search through embeddings, we highly recommend using [HuggingFace's](https://huggingface.co/) `gte-small` model, which has a vector size of `384`.
 
 There is a great article written by Supabase explaining why it might be a better option than OpenAI's `text-embedding-ada-002` model: [https://supabase.com/blog/fewer-dimensions-are-better-pgvector](https://supabase.com/blog/fewer-dimensions-are-better-pgvector).
-
-For performance reasons, we recommend using one vector property per database, even though it's possible to have multiple vector properties in the same Orama instance.
 
 ## Instance ID
 

--- a/packages/docs/pages/usage/insert.mdx
+++ b/packages/docs/pages/usage/insert.mdx
@@ -53,16 +53,7 @@ const harryPotterId = await insert(movieDB, {
 });
 ```
 
-## Batch insertion
-
-Most of the `insert` function internals are synchronous, so inserting a large
-number of documents in a loop could potentially block the event loop. If you
-have a lot of records, we suggest using the `insertMultiple` function.
-
-You can pass a third, optional, parameter to change the batch size (default:
-`1000`). We recommend keeping this number as low as possible to avoid blocking
-the event loop. The `batchSize` refers to the maximum number of `insert`
-operations to perform before yielding the event loop.
+If you have a lot of records, we suggest using the `insertMultiple` function as following:
 
 ```javascript copy
 const docs = [
@@ -89,82 +80,49 @@ const docs = [
   },
 ];
 
+await insertMultiple(movieDB, docs);
+```
+
+Inserting a large number of documents in a loop could potentially block the event loop.
+Instead `insertMultiple` handles this case better.
+
+You can pass a third, optional, parameter to change the batch size (default:
+`1000`). We recommend keeping this number as low as possible to avoid blocking
+the event loop. The `batchSize` refers to the maximum number of `insert`
+operations to perform before yielding the event loop.
+
+```javascript
 await insertMultiple(movieDB, docs, 500);
 ```
 
-## Unsearchable fields
+## Validation rules
 
-When working on large datasets, it is common to have documents with a large
-number of properties, and maybe some of them are not even relevant for any
-search purpose.
+Defining the schema at database creation time, Orama validates all the inserted documents following those rules:
+- throw an error if a field has an unexpected type
+- allow missing fields or fields set to `undefined`
+- allow extra fields ignoring them
 
-With that being said, let's consider the following schema:
+So the following document will be accepted:
 
 ```javascript copy
-import { create } from '@orama/orama'
+import { create, insert } from '@orama/orama'
 
-const db = await create({
+const movieDB = await create({
   schema: {
-    author: 'string',
-    quote: 'string',
-    favorite: 'boolean', // <-- unsearchable, can be used as filter
-    tags: 'string[]',
+    title: 'string',
+    year: 'number',
   },
 })
+
+await insert(movieDB, {
+  title: 'The prestige',
+  // `year` field is missing but it's ok
+  // year: 2006,
+  // Extra fields `director` and `isFavorite` will not be indexed
+  director: 'Christopher Nolan',
+  isFavorite: true,
+});
 ```
-
-Why does Orama need to know that a given property is of a certain type if is not
-searchable?
-
-The main reason for Orama to know types is because we're experimenting with the
-possibility of performing filtering operations depending on booleans, numbers,
-etc.
-
-It is possible to rewrite the schema definition above as follows:
-
-```javascript copy
-import { create } from '@orama/orama'
-
-const db = await create({
-  schema: {
-    author: 'string',
-    quote: 'string',
-  },
-})
-```
-
-and still, be able to insert documents like:
-
-```javascript copy
-{
-  'author': 'Rumi',
-  'quote': 'Patience is the key to joy',
-  'isFavorite': true,
-  'tags': ['inspirational', 'deep']
-}
-```
-
-or even documents with different shapes:
-
-```javascript copy
-[
-  {
-    author: 'Rumi',
-    quote: 'Patience is the key to joy',
-    isFavorite: true,
-    tags: ['inspirational', 'deep'],
-  },
-  {
-    author: 'Rumi',
-    quote: 'Grace comes to forgive and then forgive again',
-    score: 10,
-    link: null,
-  },
-]
-```
-
-of course, it will only be possible to perform search operations on **known properties**, in that case, `author` and `quote`, which will always need to be
-of type `string` (as stated during the schema definition).
 
 ## Custom document IDs
 

--- a/packages/docs/pages/usage/search/filters.mdx
+++ b/packages/docs/pages/usage/search/filters.mdx
@@ -2,12 +2,64 @@
 
 You can use the `filters` interface to filter the search results.
 
-Filters are available for numeric, boolean and string properties.
+Filters are available for numeric, boolean, string and enum properties.
+Depends on the type of the property, you can use different operators.
+
+## String operators
 
 On string properties it perform an exact matching on tokens so it is advised to disable stemming for the properties
 you want to use filters on (when using the default tokenizer you can provide the `stemmerSkipProperties` configuration property).
 
 If we consider the following schema:
+
+```javascript copy
+const db = await create({
+  schema: {
+    title: 'string',
+    tag: 'string'
+  },
+  components: {
+    tokenizer: {
+      stemming: true,
+      stemmerSkipProperties: ['tag']
+    }
+  }
+})
+
+const results = await search(db, {
+  term: 'prestige',
+  where: {
+    'tag': 'new',
+  },
+})
+```
+
+The `results` will contain all documents that contain the word `prestige` in the `title` property and have `tags` property equal to `new`.
+
+You can also specify a list of string, in this case it will return all documents that contain at least one of the values provided:
+
+```javascript copy
+const results = await search(db, {
+  term: 'prestige',
+  where: {
+    'tag': ['favorite', 'new'],
+  },
+})
+```
+
+## Number operators
+
+The number properties support the following operators:
+
+| Operator  | Description                    | Example                           |
+| --------- | ------------------------------ | --------------------------------- |
+| `gt`      | Greater than                   | `year: { gt: 2000 }`              |
+| `gte`     | Greater than or equal to       | `year: { gte: 2000 }`             |
+| `lt`      | Less than                      | `year: { lt: 2000 }`              |
+| `lte`     | Less than or equal to          | `year: { lte: 2000 }`             |
+| `eq`      | Equal to                       | `year: { eq: 2000 }`              |
+| `between` | Between two values (inclusive) | `year: { between: [2000, 2008] }` |
+
 
 ```javascript copy
 const db = await create({
@@ -29,11 +81,7 @@ const db = await create({
     }
   }
 })
-```
 
-We will be able to filter the search results by using the `where` property on numeric properties only:
-
-```javascript copy
 const results = await search(db, {
   term: 'prestige',
   where: {
@@ -43,26 +91,14 @@ const results = await search(db, {
     'meta.rating': {
       between: [5, 10],
     },
-    'meta.favorite': true,
-    length: {
-      gt: 60,
+    'meta.length': {
+      lte: 60,
     }
   },
 })
 ```
 
-## Filters operators
-
-As for now, the following operators are available for numeric properties:
-
-| Operator  | Description                    | Example                           |
-| --------- | ------------------------------ | --------------------------------- |
-| `gt`      | Greater than                   | `year: { gt: 2000 }`              |
-| `gte`     | Greater than or equal to       | `year: { gte: 2000 }`             |
-| `lt`      | Less than                      | `year: { lt: 2000 }`              |
-| `lte`     | Less than or equal to          | `year: { lte: 2000 }`             |
-| `eq`      | Equal to                       | `year: { eq: 2000 }`              |
-| `between` | Between two values (inclusive) | `year: { between: [2000, 2008] }` |
+## Boolean operators
 
 For boolean properties, you can simply set the property to `true` or `false`:
 
@@ -75,24 +111,12 @@ const results = await search(db, {
 })
 ```
 
-For string properties, you can specify a single string:
+## Enum operators
 
-```javascript copy
-const results = await search(db, {
-  term: 'prestige',
-  where: {
-    'meta.tags': 'new',
-  },
-})
-```
+The numeric properties support the following operators:
 
-You can also specify a list of string, in this case it will return all documents that contain at least one of the values provided:
-
-```javascript copy
-const results = await search(db, {
-  term: 'prestige',
-  where: {
-    'meta.tags': ['favorite', 'new'],
-  },
-})
-```
+| Operator  | Description                        | Example                                 |
+| --------- | ------------------------------     | ---------------------------------       |
+| `eq`      | Equal to                           | `genre: { eq: 'drama' }`                |
+| `in`      | Contained in the given array       | `genre: { in: ['drama', 'horror'] }`    |
+| `nin`     | Not contained in the given array   | `genre: { nin: ['commedy'] }`           |

--- a/packages/docs/pages/usage/search/introduction.mdx
+++ b/packages/docs/pages/usage/search/introduction.mdx
@@ -6,6 +6,7 @@ Orama provides a simple search interface that allows you to search through your 
 
 ## Searching with Orama
 
+By default, Orama uses all the string properties to perform the search.
 Let's say we have a database that contains some elements:
 
 ```javascript copy
@@ -46,18 +47,79 @@ await insert(movieDB, {
 });
 ```
 
-We can now search for one (or multiple) documents as easily as:
+We can now search for documents as easily as:
 
 ```javascript copy
 const searchResult = await search(movieDB, {
   term: 'Harry',
-  properties: '*',
 })
 ```
 
-### Search properties
+If you want to return all documents in the database, then you can omit the `term` in the search parameters.
 
-The `properties` property defines in which property to run our query.
+## What does the `search` method return?
+
+Now that we have learned how to perform **searches** on a Orama database, we can
+briefly analyze the response that Orama gives us back.
+
+Let's say we have run the following query:
+
+```javascript copy
+const searchResult = await search(movieDB, {
+  term: 'Cris',
+  properties: ['director'],
+  tolerance: 1,
+})
+```
+
+Whether the document was found or not, Orama gives back an `object` with the
+following properties:
+
+```javascript copy
+{
+  elapsed: {
+    raw: 181208,
+    formatted: '181μs',
+  },
+  count: 2,
+  hits: [
+    {
+      id: '37149225-243',
+      score: 0.23856062735983122,
+      document: {
+        title: 'Harry Potter and the Philosopher\'s Stone',
+        director: 'Chris Columbus',
+        plot: 'Harry Potter, an eleven-year-old orphan, discovers that he is a wizard and is invited to study at Hogwarts. Even as he escapes a dreary life and enters a world of magic, he finds trouble awaiting him.',
+        year: 2001,
+        isFavorite: false
+      }
+    },
+    {
+      id: '37149225-5',
+      score: 0.21267890323564321,
+      document: {
+        title: 'The prestige',
+        director: 'Christopher Nolan',
+        plot: 'Two friends and fellow magicians become bitter enemies after a sudden tragedy. As they devote themselves to this rivalry, they make sacrifices that bring them fame but with terrible consequences.',
+        year: 2006,
+        isFavorite: true
+      }
+    }
+  ]
+}
+```
+
+| Property  | Type     | Description                                                                                                         |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `elapsed` | `object` | Time taken to execute the query. <br /> Returns an object with the following shape: <br />` { raw: number, formatted: string } ` |
+| `hits`    | `object` | Array of results containing result score (from `0` to `1` based on relevance), Orama's ID, and original document.   |
+| `count`   | `number` | Number of total results.                                                                                            |
+
+In case of missing or empty `term`, all scores will be returned as `0`.
+
+## Search on specific properties
+
+The `properties` property defines in which properties to run our query.
 
 ```javascript copy
 const searchResult = await search(movieDB, {
@@ -98,6 +160,10 @@ We are now searching for all the documents that contain **`exactly`** the word
 
 > Without the `exact` property, for example, the term `Christopher Nolan` would
 > be returned as well, as it contains the word `Chris`.
+
+<Callout type="warning">
+  `exact` doesn't work together with the `tolerance` parameter. `exact` will have priority.
+</Callout>
 
 ## Typo tolerance
 
@@ -158,63 +224,24 @@ We are searching for all the documents that contains the term `Chris` in the
   By default, Orama limits the search results to `10`, without any offset (so, `0` as offset value).
 </Callout>
 
-## What does the `search` method return?
+## Distinct
 
-Now that we have learned how to perform **searches** on a Orama database, we can
-briefly analyze the response that Orama gives us back.
-
-Let's say we have run the following query:
-
+Orama can calculate distinct values letting you specify a unique key as follows:
 ```javascript copy
-const searchResult = await search(movieDB, {
-  term: 'Cris',
-  properties: ['director'],
-  tolerance: 1,
+const results = await search(db, {
+  distinctOn: 'type',
+  sortBy: {
+    property: 'rank',
+    order: 'DESC',
+  }
 })
 ```
+Using the property `distinctOn`, Orama returns only the first document for every property `type` value.
+The `results.hits` array will contain only the first documents for every property `type` value.
 
-Whether the document was found or not, Orama gives back an `object` with the
-following properties:
+NB: you can use this feature in combination with `sortBy`.
 
-```javascript copy
-{
-  elapsed: {
-    raw: 181208,
-    formatted: '181μs',
-  },
-  count: 2,
-  hits: [
-    {
-      id: '37149225-243',
-      score: 0.23856062735983122,
-      document: {
-        title: 'Harry Potter and the Philosopher\'s Stone',
-        director: 'Chris Columbus',
-        plot: 'Harry Potter, an eleven-year-old orphan, discovers that he is a wizard and is invited to study at Hogwarts. Even as he escapes a dreary life and enters a world of magic, he finds trouble awaiting him.',
-        year: 2001,
-        isFavorite: false
-      }
-    },
-    {
-      id: '37149225-5',
-      score: 0.21267890323564321,
-      document: {
-        title: 'The prestige',
-        director: 'Christopher Nolan',
-        plot: 'Two friends and fellow magicians become bitter enemies after a sudden tragedy. As they devote themselves to this rivalry, they make sacrifices that bring them fame but with terrible consequences.',
-        year: 2006,
-        isFavorite: true
-      }
-    }
-  ]
-}
-```
-
-| Property  | Type     | Description                                                                                                         |
-| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `elapsed` | `object` | Time taken to execute the query. <br /> Returns an object with the following shape: <br />` { raw: number, formatted: string } ` |
-| `hits`    | `object` | Array of results containing result score (from `0` to `1` based on relevance), Orama's ID, and original document.   |
-| `count`   | `number` | Number of total results.                                                                                            |
+## `elapsed` property customization
 
 You can always customize the behavior of the `elapsed` property by using the `formatElapsedTime` component when creating a new Orama instance:
 
@@ -241,23 +268,3 @@ When performing a search operation, the `elapsed` property will now return the f
   hits: [...]
 }
 ```
-
-If you want to return all documents in the database, then you can omit the `term` in the search parameters.
-This kind of search might be slower than a regular search and all scores will be returned as `0`.
-
-## Distinct
-
-Orama can calculate distinct values letting you specify a unique key as follows:
-```javascript copy
-const results = await search(db, {
-  distinctOn: 'type',
-  sortBy: {
-    property: 'rank',
-    order: 'DESC',
-  }
-})
-```
-Using the property `distinctOn`, Orama returns only the first document for every property `type` value.
-The `results.hits` array will contain only the first documents for every property `type` value.
-
-NB: you can use this feature in combination with `sortBy`.

--- a/packages/orama/src/components/defaults.ts
+++ b/packages/orama/src/components/defaults.ts
@@ -32,6 +32,10 @@ export async function validateSchema<S extends Schema = Schema>(doc: Document, s
       continue
     }
 
+    if (type === 'enum' && (typeOfValue === 'string' || typeOfValue === 'number')) {
+      continue
+    }
+
     const typeOfType = typeof type
 
     if (isVectorType(type as string)) {
@@ -82,6 +86,7 @@ const IS_ARRAY_TYPE: Record<SearchableType, boolean> = {
   string: false,
   number: false,
   boolean: false,
+  enum: false,
   'string[]': true,
   'number[]': true,
   'boolean[]': true,

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -2,6 +2,7 @@ import type {
   ArraySearchableType,
   BM25Params,
   ComparisonOperator,
+  EnumComparisonOperator,
   IIndex,
   Magnitude,
   OpaqueDocumentStore,
@@ -34,7 +35,13 @@ import {
   Node as RadixNode,
   removeDocumentByWord as radixRemoveDocument,
 } from '../trees/radix.js'
-import { intersect, safeArrayPush } from '../utils.js';
+import {
+  create as flatCreate,
+  insert as flatInsert,
+  removeDocument as flatRemoveDocument,
+  filter as flatFilter,
+} from '../trees/flat.js'
+import { intersect, safeArrayPush } from '../utils.js'
 import { BM25 } from './algorithms.js'
 import { getInnerType, getVectorSize, isArrayType, isVectorType } from './defaults.js'
 import {
@@ -44,6 +51,7 @@ import {
   InternalDocumentIDStore,
 } from './internal-document-id-store.js'
 import { getMagnitude } from './cosine-similarity.js'
+import { FlatTree } from '../trees/flat.js'
 
 export type FrequencyMap = {
   [property: string]: {
@@ -67,9 +75,23 @@ export type VectorIndex = {
   }
 }
 
+export type Tree = {
+  type: 'radix'
+  node: RadixNode
+} | {
+  type: 'avl'
+  node: AVLNode<number, InternalDocumentID[]>
+} | {
+  type: 'bool'
+  node: BooleanIndex
+} | {
+  type: 'flat'
+  node: FlatTree
+}
+
 export interface Index extends OpaqueIndex {
   sharedInternalDocumentStore: InternalDocumentIDStore
-  indexes: Record<string, RadixNode | AVLNode<number, InternalDocumentID[]> | BooleanIndex>
+  indexes: Record<string, Tree>
   vectorIndexes: Record<string, VectorIndex>
   searchableProperties: string[]
   searchablePropertiesWithTypes: Record<string, SearchableType>
@@ -223,19 +245,22 @@ export async function create(
       switch (type) {
         case 'boolean':
         case 'boolean[]':
-          index.indexes[path] = { true: [], false: [] }
+          index.indexes[path] = { type: 'bool', node: { true: [], false: [] } }
           break
         case 'number':
         case 'number[]':
-          index.indexes[path] = avlCreate<number, InternalDocumentID[]>(0, [])
+          index.indexes[path] = { type: 'avl', node: avlCreate<number, InternalDocumentID[]>(0, []) }
           break
         case 'string':
         case 'string[]':
-          index.indexes[path] = radixCreate()
+          index.indexes[path] = { type: 'radix', node: radixCreate() }
           index.avgFieldLength[path] = 0
           index.frequencies[path] = {}
           index.tokenOccurrences[path] = {}
           index.fieldLengths[path] = {}
+          break
+        case 'enum':
+          index.indexes[path] = { type: 'flat', node: flatCreate() }
           break
         default:
           throw createError('INVALID_SCHEMA_TYPE', Array.isArray(type) ? 'array' : (type as unknown as string), path)
@@ -262,25 +287,29 @@ async function insertScalar(
 ): Promise<void> {
   const internalId = getInternalDocumentId(index.sharedInternalDocumentStore, id)
 
-  switch (schemaType) {
-    case 'boolean': {
-      const booleanIndex = index.indexes[prop] as BooleanIndex
-      booleanIndex[value ? 'true' : 'false'].push(internalId)
+  const { type, node } = index.indexes[prop]
+  switch (type) {
+    case 'bool': {
+      node[value ? 'true' : 'false'].push(internalId)
       break
     }
-    case 'number':
-      avlInsert(index.indexes[prop] as AVLNode<number, number[]>, value as number, [internalId])
+    case 'avl':
+      avlInsert(node, value as number, [internalId])
       break
-    case 'string': {
+    case 'radix': {
       const tokens = await tokenizer.tokenize(value as string, language, prop)
       await implementation.insertDocumentScoreParameters(index, prop, internalId, tokens, docsCount)
 
       for (const token of tokens) {
         await implementation.insertTokenScoreParameters(index, prop, internalId, tokens, token)
 
-        radixInsert(index.indexes[prop] as RadixNode, token, internalId)
+        radixInsert(node, token, internalId)
       }
 
+      break
+    }
+    case 'flat': {
+      flatInsert(node, value as ScalarSearchableType, internalId)
       break
     }
   }
@@ -348,28 +377,33 @@ async function removeScalar(
 ): Promise<boolean> {
   const internalId = getInternalDocumentId(index.sharedInternalDocumentStore, id)
 
-  switch (schemaType) {
-    case 'number': {
-      avlRemoveDocument(index.indexes[prop] as AVLNode<number, InternalDocumentID[]>, internalId, value)
+  const { type, node } = index.indexes[prop]
+  switch (type) {
+    case 'avl': {
+      avlRemoveDocument(node, internalId, value as number)
       return true
     }
-    case 'boolean': {
+    case 'bool': {
       const booleanKey = value ? 'true' : 'false'
-      const position = (index.indexes[prop] as BooleanIndex)[booleanKey].indexOf(internalId)
+      const position = node[booleanKey].indexOf(internalId)
 
-      ;(index.indexes[prop] as BooleanIndex)[value ? 'true' : 'false'].splice(position, 1)
+      node[value ? 'true' : 'false'].splice(position, 1)
       return true
     }
-    case 'string': {
+    case 'radix': {
       const tokens = await tokenizer.tokenize(value as string, language, prop)
 
       await implementation.removeDocumentScoreParameters(index, prop, id, docsCount)
 
       for (const token of tokens) {
         await implementation.removeTokenScoreParameters(index, prop, token)
-        radixRemoveDocument(index.indexes[prop] as RadixNode, token, internalId)
+        radixRemoveDocument(node, token, internalId)
       }
 
+      return true
+    }
+    case 'flat': {
+      flatRemoveDocument(node, internalId, value as ScalarSearchableType)
       return true
     }
   }
@@ -421,10 +455,13 @@ export async function search<D extends OpaqueDocumentStore, AggValue>(
     return []
   }
 
-  // Performa the search
-  const rootNode = index.indexes[prop] as RadixNode
+  const { node, type } = index.indexes[prop]
+  if (type !== 'radix') {
+    throw createError('WRONG_SEARCH_PROPERTY_TYPE', prop)
+  }
+
   const { exact, tolerance } = context.params
-  const searchResult = radixFind(rootNode, { term, exact, tolerance })
+  const searchResult = radixFind(node, { term, exact, tolerance })
   const ids = new Set<InternalDocumentID>()
 
   for (const key in searchResult) {
@@ -439,7 +476,7 @@ export async function search<D extends OpaqueDocumentStore, AggValue>(
 export async function searchByWhereClause<I extends OpaqueIndex, D extends OpaqueDocumentStore, AggValue>(
   context: SearchContext<I, D, AggValue>,
   index: Index,
-  filters: Record<string, boolean | ComparisonOperator>,
+  filters: Record<string, boolean | ComparisonOperator | EnumComparisonOperator>,
 ): Promise<number[]> {
   const filterKeys = Object.keys(filters)
 
@@ -454,29 +491,24 @@ export async function searchByWhereClause<I extends OpaqueIndex, D extends Opaqu
   for (const param of filterKeys) {
     const operation = filters[param]
 
-    if (typeof operation === 'boolean') {
-      const idx = index.indexes[param] as BooleanIndex
+    if (typeof index.indexes[param] === 'undefined') {
+      throw createError('UNKNOWN_FILTER_PROPERTY', param)
+    }
 
-      if (typeof idx === 'undefined') {
-        throw createError('UNKNOWN_FILTER_PROPERTY', param)
-      }
+    const { node, type } = index.indexes[param]
 
+    if (type === 'bool') {
+      const idx = node
       const filteredIDs = idx[operation.toString() as keyof BooleanIndex]
       safeArrayPush(filtersMap[param], filteredIDs);
       continue
     }
 
-    if (typeof operation === 'string' || Array.isArray(operation)) {
-      const idx = index.indexes[param] as RadixNode
-
-      if (typeof idx === 'undefined') {
-        throw createError('UNKNOWN_FILTER_PROPERTY', param)
-      }
-
+    if (type === 'radix' && (typeof operation === 'string' || Array.isArray(operation))) {
       for (const raw of [operation].flat()) {
         const term = await context.tokenizer.tokenize(raw, context.language, param)
         for (const t of term) {
-          const filteredIDsResults = radixFind(idx, { term: t, exact: true })
+          const filteredIDsResults = radixFind(node, { term: t, exact: true })
           safeArrayPush(filtersMap[param], Object.values(filteredIDsResults).flat())}
       }
 
@@ -489,46 +521,47 @@ export async function searchByWhereClause<I extends OpaqueIndex, D extends Opaqu
       throw createError('INVALID_FILTER_OPERATION', operationKeys.length)
     }
 
-    const operationOpt = operationKeys[0] as keyof ComparisonOperator
-    const operationValue = operation[operationOpt]
-
-    const AVLNode = index.indexes[param] as AVLNode<number, InternalDocumentID[]>
-
-    if (typeof AVLNode === 'undefined') {
-      throw createError('UNKNOWN_FILTER_PROPERTY', param)
+    if (type === 'flat') {
+      filtersMap[param].push(...flatFilter(node, operation as EnumComparisonOperator))
+      continue
     }
 
-    let filteredIDs = [];
 
-    switch (operationOpt) {
-      case 'gt': {
-        filteredIDs = avlGreaterThan(AVLNode, operationValue, false)
-        break
+    if (type === 'avl') {
+      const operationOpt = operationKeys[0] as keyof ComparisonOperator
+      const operationValue = (operation as ComparisonOperator)[operationOpt]
+      let filteredIDs = [];
+
+      switch (operationOpt) {
+        case 'gt': {
+          filteredIDs = avlGreaterThan(node, operationValue, false)
+          break
+        }
+        case 'gte': {
+          filteredIDs = avlGreaterThan(node, operationValue, true)
+          break
+        }
+        case 'lt': {
+          filteredIDs = avlLessThan(node, operationValue, false)
+          break
+        }
+        case 'lte': {
+          filteredIDs = avlLessThan(node, operationValue, true)
+          break
+        }
+        case 'eq': {
+          filteredIDs = avlFind(node, operationValue) ?? []
+          break
+        }
+        case 'between': {
+          const [min, max] = operationValue as number[]
+          filteredIDs = avlRangeSearch(node, min, max)
+          break
+        }
       }
-      case 'gte': {
-        filteredIDs = avlGreaterThan(AVLNode, operationValue, true)
-        break
-      }
-      case 'lt': {
-        filteredIDs = avlLessThan(AVLNode, operationValue, false)
-        break
-      }
-      case 'lte': {
-        filteredIDs = avlLessThan(AVLNode, operationValue, true)
-        break
-      }
-      case 'eq': {
-        filteredIDs = avlFind(AVLNode, operationValue) ?? []
-        break
-      }
-      case 'between': {
-        const [min, max] = operationValue as number[]
-        filteredIDs = avlRangeSearch(AVLNode, min, max)
-        break
-      }
+
+      safeArrayPush(filtersMap[param], filteredIDs)
     }
-
-    safeArrayPush(filtersMap[param], filteredIDs)
   }
 
   // AND operation: calculate the intersection between all the IDs in filterMap
@@ -574,15 +607,17 @@ export async function load<R = unknown>(sharedInternalDocumentStore: InternalDoc
   const vectorIndexes: Index['vectorIndexes'] = {}
 
   for (const prop of Object.keys(rawIndexes)) {
-    const value = rawIndexes[prop]
+    const { node, type } = rawIndexes[prop]
 
-    if (!('word' in value)) {
-      indexes[prop] = value
-
+    if (type !== 'radix') {
+      indexes[prop] = rawIndexes[prop]
       continue
     }
 
-    indexes[prop] = loadNode(value)
+    indexes[prop] = {
+      type: 'radix',
+      node: loadNode(node)
+    }
   }
 
   for (const idx of Object.keys(rawVectorIndexes)) {

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -624,7 +624,7 @@ export async function load<R = unknown>(sharedInternalDocumentStore: InternalDoc
     const { node, type } = rawIndexes[prop]
 
     switch (type) {
-      case TreeType.Radix: 
+      case TreeType.Radix:
         indexes[prop] = {
           type: TreeType.Radix,
           node: loadRadixNode(node)

--- a/packages/orama/src/components/sorter.ts
+++ b/packages/orama/src/components/sorter.ts
@@ -85,6 +85,7 @@ function innerCreate(
             type: type,
           }
           break
+        case 'enum':
         case 'boolean[]':
         case 'number[]':
         case 'string[]':

--- a/packages/orama/src/errors.ts
+++ b/packages/orama/src/errors.ts
@@ -32,6 +32,7 @@ const errors = {
   INVALID_VECTOR_SIZE: `Vector size must be a number greater than 0. Got "%s" instead.`,
   INVALID_VECTOR_VALUE: `Vector value must be a number greater than 0. Got "%s" instead.`,
   INVALID_INPUT_VECTOR: `Property "%s" was declared as a %s-dimentional vector, but got a %s-dimentional vector instead.\nInput vectors must be of the size declared in the schema, as calculating similarity between vectors of different sizes can lead to unexpected results.`,
+  WRONG_SEARCH_PROPERTY_TYPE: `Property "%s" is not searchable. Only "string" properties are searchable.`,
 }
 
 export type ErrorCode = keyof typeof errors

--- a/packages/orama/src/methods/insert.ts
+++ b/packages/orama/src/methods/insert.ts
@@ -53,6 +53,10 @@ async function innerInsert(orama: Orama, doc: Document, language?: string, skipH
       continue
     }
 
+    if (expectedType === 'enum' && (actualType === 'string' || actualType === 'number')) {
+      continue
+    }
+
     if (actualType !== expectedType) {
       throw createError('INVALID_DOCUMENT_PROPERTY', key, expectedType, actualType)
     }

--- a/packages/orama/src/trees/flat.ts
+++ b/packages/orama/src/trees/flat.ts
@@ -73,6 +73,22 @@ export function filter(root: FlatTree, operation: EnumComparisonOperator): Inter
       }
       return result
     }
+    case 'nin': {
+      const value = operation[operationType]!
+      const result: InternalDocumentID[] = []
+
+      const keys = root.numberToDocumentId.keys()
+      for (const key of keys) {
+        if (value.includes(key)) {
+          continue
+        }
+        const ids = root.numberToDocumentId.get(key)
+        if (ids) {
+          result.push(...ids)
+        }
+      }
+      return result
+    }
   }
 
   throw new Error('Invalid operation')

--- a/packages/orama/src/trees/flat.ts
+++ b/packages/orama/src/trees/flat.ts
@@ -1,0 +1,79 @@
+import { InternalDocumentID } from "../components/internal-document-id-store.js"
+import { EnumComparisonOperator, ScalarSearchableValue } from "../types.js"
+
+export interface FlatTree {
+  numberToDocumentId: Map<ScalarSearchableValue, InternalDocumentID[]>
+}
+
+export function create(): FlatTree {
+  return {
+    numberToDocumentId: new Map()
+  }
+}
+
+export function insert(root: FlatTree, key: ScalarSearchableValue, value: InternalDocumentID): FlatTree {
+  if (root.numberToDocumentId.has(key)) {
+    root.numberToDocumentId.get(key)!.push(value)
+    return root
+  }
+  root.numberToDocumentId.set(key, [value])
+  return root
+}
+
+export function find(root: FlatTree, key: ScalarSearchableValue): InternalDocumentID[] | null {
+  return root.numberToDocumentId.get(key) ?? null
+}
+
+export function remove(root: FlatTree | null, key: ScalarSearchableValue): FlatTree | null {
+  if (root) {
+    root.numberToDocumentId.delete(key)
+  }
+  return root
+}
+export function removeDocument(root: FlatTree, id: InternalDocumentID, key: ScalarSearchableValue): void {
+  root?.numberToDocumentId.set(key, root?.numberToDocumentId.get(key)?.filter((v) => v !== id) ?? [])
+  if (root?.numberToDocumentId.get(key)?.length === 0) {
+    root?.numberToDocumentId.delete(key)
+  }
+}
+
+
+export function contains(node: FlatTree, key: ScalarSearchableValue): boolean {
+  return !!find(node, key)
+}
+
+export function getSize(root: FlatTree | null): number {
+  let size = 0
+  for (const [, value] of root?.numberToDocumentId ?? []) {
+    size += value.length
+  }
+  return size
+}
+export function filter(root: FlatTree, operation: EnumComparisonOperator): InternalDocumentID[] {
+  const operationKeys = Object.keys(operation)
+
+  if (operationKeys.length !== 1) {
+    throw new Error('Invalid operation')
+  }
+
+  const operationType = operationKeys[0] as keyof EnumComparisonOperator
+  switch (operationType) {
+    case 'eq': {
+      const value = operation[operationType]!
+      return root.numberToDocumentId.get(value) ?? []
+    }
+    case 'in': {
+      const value = operation[operationType]!
+      const result: InternalDocumentID[] = []
+      for (const v of value) {
+        const ids = root.numberToDocumentId.get(v)
+        if (ids) {
+          result.push(...ids)
+        }
+      }
+      return result
+    }
+  }
+
+  throw new Error('Invalid operation')
+}

--- a/packages/orama/src/trees/flat.ts
+++ b/packages/orama/src/trees/flat.ts
@@ -1,5 +1,5 @@
 import { InternalDocumentID } from "../components/internal-document-id-store.js"
-import { EnumComparisonOperator, ScalarSearchableValue } from "../types.js"
+import { EnumComparisonOperator, Nullable, ScalarSearchableValue } from "../types.js"
 
 export interface FlatTree {
   numberToDocumentId: Map<ScalarSearchableValue, InternalDocumentID[]>
@@ -20,11 +20,11 @@ export function insert(root: FlatTree, key: ScalarSearchableValue, value: Intern
   return root
 }
 
-export function find(root: FlatTree, key: ScalarSearchableValue): InternalDocumentID[] | null {
+export function find(root: FlatTree, key: ScalarSearchableValue): Nullable<InternalDocumentID[]> {
   return root.numberToDocumentId.get(key) ?? null
 }
 
-export function remove(root: FlatTree | null, key: ScalarSearchableValue): FlatTree | null {
+export function remove(root: Nullable<FlatTree>, key: ScalarSearchableValue): Nullable<FlatTree> {
   if (root) {
     root.numberToDocumentId.delete(key)
   }
@@ -42,7 +42,7 @@ export function contains(node: FlatTree, key: ScalarSearchableValue): boolean {
   return !!find(node, key)
 }
 
-export function getSize(root: FlatTree | null): number {
+export function getSize(root: Nullable<FlatTree>): number {
   let size = 0
   for (const [, value] of root?.numberToDocumentId ?? []) {
     size += value.length

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -94,6 +94,7 @@ export type ComparisonOperator = {
 export type EnumComparisonOperator = {
   eq?: string | number | boolean
   in?: (string | number | boolean)[]
+  nin?: (string | number | boolean)[]
 }
 
 /**

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -26,8 +26,9 @@ export type Magnitude = number
 export type Vector = `vector[${number}]`
 export type VectorType = Float32Array
 
-export type ScalarSearchableType = 'string' | 'number' | 'boolean'
+export type ScalarSearchableType = 'string' | 'number' | 'boolean' | 'enum'
 export type ArraySearchableType = 'string[]' | 'number[]' | 'boolean[]' | Vector
+
 export type SearchableType = ScalarSearchableType | ArraySearchableType
 
 export type ScalarSearchableValue = string | number | boolean
@@ -88,6 +89,11 @@ export type ComparisonOperator = {
   lte?: number
   eq?: number
   between?: [number, number]
+}
+
+export type EnumComparisonOperator = {
+  eq?: string | number | boolean
+  in?: (string | number | boolean)[]
 }
 
 /**
@@ -248,7 +254,7 @@ export type SearchParams<T = Result[]> = {
    *  }
    * });
    */
-  where?: Record<string, boolean | string | string[] | ComparisonOperator>
+  where?: Record<string, boolean | string | string[] | ComparisonOperator | EnumComparisonOperator>
 
   /**
    * Threshold to use for refining the search results.
@@ -466,7 +472,7 @@ export interface IIndex<I extends OpaqueIndex = OpaqueIndex> {
   searchByWhereClause<D extends OpaqueDocumentStore, AggValue = Result[]>(
     context: SearchContext<I, D, AggValue>,
     index: I,
-    filters: Record<string, boolean | string | string[] | ComparisonOperator>,
+    filters: Record<string, boolean | string | string[] | ComparisonOperator | EnumComparisonOperator>,
   ): SyncOrAsyncValue<InternalDocumentID[]>
 
   getSearchableProperties(index: I): SyncOrAsyncValue<string[]>

--- a/packages/orama/tests/enum.test.ts
+++ b/packages/orama/tests/enum.test.ts
@@ -165,14 +165,13 @@ t.test('enum', async t => {
     ])
 
     const dump = await save(db1)
-    const dump2 = JSON.parse(JSON.stringify(dump))
 
     const db2 = await create({
       schema: {
         categoryId: 'enum',
       },
     })
-    await load(db2, dump2)
+    await load(db2, dump)
 
     const result1 = await search(db2, {
       term: '',

--- a/packages/orama/tests/enum.test.ts
+++ b/packages/orama/tests/enum.test.ts
@@ -1,0 +1,208 @@
+import t from 'tap'
+import { ScalarSearchableValue, create, insert, insertMultiple, load, remove, save, search } from '../src/index.js'
+
+t.test('enum', async t => {
+
+  t.test('search', async t => {
+    const db = await create({
+      schema: {
+        categoryId: 'enum',
+      },
+    })
+
+    const c1 = await insert(db, {
+      categoryId: 1,
+    })
+    const [c11, c2, c3, c5] = await insertMultiple(db, [
+      { categoryId: 1 },
+      { categoryId: 2 },
+      { categoryId: 3 },
+      { categoryId: "5" },
+    ])
+
+    const tests: {value: ScalarSearchableValue, expected: string[] }[] = [
+      { value: 1, expected: [c1, c11] },
+      { value: 2, expected: [c2] },
+      { value: 3, expected: [c3] },
+      { value: '5', expected: [c5] },
+      { value: 'unknown', expected: [] },
+    ]
+
+    t.test('eq operator', async t => {
+      for (const { value, expected } of tests) {
+        t.test(`search for ${value}`, async t => {
+          const result = await search(db, {
+            term: '',
+            where: {
+              categoryId: { eq: value },
+            }
+          })
+          t.equal(result.hits.length, expected.length)
+          t.strictSame(result.hits.map(h => h.id), expected)
+
+          t.end()
+        })
+      }
+    })
+
+    t.test('in operator', async t => {
+      for (const { value, expected } of tests) {
+        t.test(`search for [${value}]`, async t => {
+          const result = await search(db, {
+            term: '',
+            where: {
+              categoryId: { in: [value] },
+            }
+          })
+          t.equal(result.hits.length, expected.length)
+          t.strictSame(result.hits.map(h => h.id), expected)
+
+          t.end()
+        })
+      }
+
+      t.test(`search for [1, 3, "5", 'unknown']`, async t => {
+        const result = await search(db, {
+          term: '',
+          where: {
+            categoryId: { in: [1, 3, "5", 'unknown'] },
+          }
+        })
+        t.equal(result.hits.length, 4)
+        t.strictSame(result.hits.map(h => h.id), [c1, c11, c3, c5])
+
+        t.end()
+      })
+    })
+
+    t.end()
+  })
+
+  t.test(`remove document works fine`, async t => {
+    const db = await create({
+      schema: {
+        categoryId: 'enum',
+      },
+    })
+    const c1 = await insert(db, { categoryId: 1 })
+    const c11 = await insert(db, { categoryId: 1 })
+
+    const result1 = await search(db, {
+      term: '',
+      where: { categoryId: { eq: 1 }, }
+    })
+    t.equal(result1.hits.length, 2)
+    t.strictSame(result1.hits.map(h => h.id), [c1, c11])
+
+    await remove(db, c1)
+
+    const result2 = await search(db, {
+      term: '',
+      where: { categoryId: { eq: 1 }, }
+    })
+    t.equal(result2.hits.length, 1)
+    t.strictSame(result2.hits.map(h => h.id), [c11])
+
+    t.end()
+  })
+
+  t.test(`still serializable`, async t => {
+    const db1 = await create({
+      schema: {
+        categoryId: 'enum',
+      },
+    })
+    const [c1, c11, c2, c3, c5] = await insertMultiple(db1, [
+      { categoryId: 1 },
+      { categoryId: 1 },
+      { categoryId: 2 },
+      { categoryId: 3 },
+      { categoryId: "5" },
+    ])
+
+    const dump = await save(db1)
+
+    const db2 = await create({
+      schema: {
+        categoryId: 'enum',
+      },
+    })
+    await load(db2, dump)
+
+    const result1 = await search(db2, {
+      term: '',
+      where: {
+        categoryId: { eq: 1 },
+      }
+    })
+    t.equal(result1.hits.length, 2)
+    t.strictSame(result1.hits.map(h => h.id), [c1, c11])
+
+    const result2 = await search(db2, {
+      term: '',
+      where: {
+        categoryId: { in: [1, 2, 3, '5', 'unknown'] },
+      }
+    })
+    t.equal(result2.hits.length, 5)
+    t.strictSame(result2.hits.map(h => h.id), [c1, c11, c2, c3, c5])
+
+    t.end()
+  })
+
+  t.test(`complex example`, async t => {
+    const filmDb = await create({
+      schema: {
+        title: 'string',
+        year: 'number',
+        categoryId: 'enum',
+      },
+    })
+    const [c1] = await insertMultiple(filmDb, [
+      { title: 'The Shawshank Redemption', year: 1994, categoryId: 1 },
+      { title: 'The Godfather', year: 1972, categoryId: 1 },
+      { title: 'The Dark Knight', year: 2008, categoryId: 2 },
+      { title: 'Schindler\'s List', year: 1993, categoryId: 3 },
+      { title: 'The Lord of the Rings: The Return of the King', year: 2003, categoryId: 4 },
+    ])
+
+
+    const result1 = await search(filmDb, {
+      term: 'r',
+    })
+    t.equal(result1.hits.length, 2)
+
+    const result2 = await search(filmDb, {
+      term: 'r',
+      where: {
+        categoryId: { eq: 1 },
+      }
+    })
+    t.equal(result2.hits.length, 1)
+    t.strictSame(result2.hits.map(h => h.id), [c1])
+
+    const result3 = await search(filmDb, {
+      term: 'r',
+      where: {
+        year: { gt: 2000 },
+        categoryId: { eq: 1 },
+      }
+    })
+    t.equal(result3.hits.length, 0)
+    t.strictSame(result3.hits.map(h => h.id), [])
+
+    const result4 = await search(filmDb, {
+      term: 'r',
+      where: {
+        year: { lte: 2000 },
+        categoryId: { eq: 1 },
+      }
+    })
+    t.equal(result4.hits.length, 1)
+    t.strictSame(result4.hits.map(h => h.id), [c1])
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/packages/orama/tests/enum.test.ts
+++ b/packages/orama/tests/enum.test.ts
@@ -121,13 +121,14 @@ t.test('enum', async t => {
     ])
 
     const dump = await save(db1)
+    const dump2 = JSON.parse(JSON.stringify(dump))
 
     const db2 = await create({
       schema: {
         categoryId: 'enum',
       },
     })
-    await load(db2, dump)
+    await load(db2, dump2)
 
     const result1 = await search(db2, {
       term: '',

--- a/packages/orama/tests/serialization.test.ts
+++ b/packages/orama/tests/serialization.test.ts
@@ -38,8 +38,8 @@ t.test('Edge getters', t => {
     const nameIndex = (index as Index).indexes['name']
 
     // Remember that tokenizers an stemmers sets content to lowercase
-    t.ok(trieContains(nameIndex as RadixNode, 'john'))
-    t.ok(trieContains(nameIndex as RadixNode, 'jane'))
+    t.ok(trieContains(nameIndex.node as RadixNode, 'john'))
+    t.ok(trieContains(nameIndex.node as RadixNode, 'jane'))
   })
 
   t.test('should correctly enable edge docs getter', async t => {

--- a/packages/plugin-data-persistence/test/index.test.ts
+++ b/packages/plugin-data-persistence/test/index.test.ts
@@ -24,23 +24,27 @@ async function generateTestDBInstance(): Promise<Orama<any>> {
   const db = await create({
     schema: {
       quote: 'string',
-      author: 'string'
+      author: 'string',
+      genre: 'enum'
     }
   })
 
   await insert(db, {
     quote: 'I am a great programmer',
-    author: 'Bill Gates'
+    author: 'Bill Gates',
+    genre: 'tech'
   })
 
   await insert(db, {
     quote: 'Be yourself; everyone else is already taken.',
-    author: 'Oscar Wilde'
+    author: 'Oscar Wilde',
+    genre: 'life'
   })
 
   await insert(db, {
     quote: "I have not failed. I've just found 10,000 ways that won't work.",
-    author: 'Thomas A. Edison'
+    author: 'Thomas A. Edison',
+    genre: 'tech'
   })
 
   await insert(db, {
@@ -180,6 +184,30 @@ t.test('binary persistence', t => {
       }
     }
   })
+
+  t.test('should continue to work with `enum`', async t => {
+    t.plan(2)
+
+    const db = await generateTestDBInstance()
+    const q1 = await search(db, {
+      where: {
+        genre: { eq: 'way' }
+      }
+    })
+
+    const path = await persistToFile(db, 'binary', 'test.dpack')
+    const db2 = await restoreFromFile('binary', 'test.dpack')
+
+    const qp1 = await search(db2, {
+      where: {
+        genre: { eq: 'way' }
+      }
+    })
+
+    t.same(q1.hits, qp1.hits)
+
+    await rm(path)
+  })
 })
 
 t.test('json persistence', t => {
@@ -289,6 +317,30 @@ t.test('json persistence', t => {
     // Clean up
     await rm(path)
   })
+
+  t.test('should continue to work with `enum`', async t => {
+    t.plan(2)
+
+    const db = await generateTestDBInstance()
+    const q1 = await search(db, {
+      where: {
+        genre: { eq: 'way' }
+      }
+    })
+
+    const path = await persistToFile(db, 'json', 'test.json')
+    const db2 = await restoreFromFile('json', 'test.json')
+
+    const qp1 = await search(db2, {
+      where: {
+        genre: { eq: 'way' }
+      }
+    })
+
+    t.same(q1.hits, qp1.hits)
+
+    await rm(path)
+  })
 })
 
 t.test('dpack persistence', t => {
@@ -359,6 +411,30 @@ t.test('dpack persistence', t => {
     t.same(q2.hits, qp2.hits)
 
     // Clean up
+    await rm(path)
+  })
+
+  t.test('should continue to work with `enum`', async t => {
+    t.plan(2)
+
+    const db = await generateTestDBInstance()
+    const q1 = await search(db, {
+      where: {
+        genre: { eq: 'way' }
+      }
+    })
+
+    const path = await persistToFile(db, 'dpack', 'test.dpack')
+    const db2 = await restoreFromFile('dpack', 'test.dpack')
+
+    const qp1 = await search(db2, {
+      where: {
+        genre: { eq: 'way' }
+      }
+    })
+
+    t.same(q1.hits, qp1.hits)
+
     await rm(path)
   })
 })

--- a/packages/plugin-data-persistence/test/index.test.ts
+++ b/packages/plugin-data-persistence/test/index.test.ts
@@ -56,7 +56,7 @@ async function generateTestDBInstance(): Promise<Orama<any>> {
 }
 
 t.test('binary persistence', t => {
-  t.plan(3)
+  t.plan(4)
 
   t.test('should generate a persistence file on the disk with random name', async t => {
     t.plan(2)
@@ -186,7 +186,7 @@ t.test('binary persistence', t => {
   })
 
   t.test('should continue to work with `enum`', async t => {
-    t.plan(2)
+    t.plan(1)
 
     const db = await generateTestDBInstance()
     const q1 = await search(db, {
@@ -211,7 +211,7 @@ t.test('binary persistence', t => {
 })
 
 t.test('json persistence', t => {
-  t.plan(3)
+  t.plan(4)
 
   t.test('should generate a persistence file on the disk with random name and json format', async t => {
     t.plan(2)
@@ -319,7 +319,7 @@ t.test('json persistence', t => {
   })
 
   t.test('should continue to work with `enum`', async t => {
-    t.plan(2)
+    t.plan(1)
 
     const db = await generateTestDBInstance()
     const q1 = await search(db, {
@@ -344,7 +344,7 @@ t.test('json persistence', t => {
 })
 
 t.test('dpack persistence', t => {
-  t.plan(2)
+  t.plan(3)
 
   t.test('should generate a persistence file on the disk with random name and dpack format', async t => {
     t.plan(2)
@@ -415,7 +415,7 @@ t.test('dpack persistence', t => {
   })
 
   t.test('should continue to work with `enum`', async t => {
-    t.plan(2)
+    t.plan(1)
 
     const db = await generateTestDBInstance()
     const q1 = await search(db, {


### PR DESCRIPTION
We collect some issues for our performance during the insertion. In particular, the number type has some problems if the number of documents is high. But also string can be slow too. 

The issue related to the insertion time is because of the cost of keeping the order for the number. Trees allow us to keep order with the cost of O(log(N)) for insertion time. But what happens if we choose to lose the order to have a faster insertion time?

Depending on what you need, values can have a lot of meanings:
- strings you want to search for
- numbers you want to compare with operators (`>`, `<`, `>=`, `<=`, `=`, `!=`)
- enum you want to compare with operators (`=`, `in`)

This PR introduces the `enum` type to allow:
- fast insertion
- fast search
- `=` and `in` operator (others??)
- reduce the dump size

What this PR misses:
- [x] tests: done
- [x] we need to identify `FlatTree` properly: used a discriminator string
- [x] choose if we want to support `enum[]` as well: discarded for now
- [x] documentation: done
- [x] collect suggestions and comment: done


Usage:
```ts
const db = await create({
  schema: {
    categoryId: 'enum',
  },
})

const [c2, c3, c5] = await insertMultiple(db, [
  { categoryId: 1 },
  { categoryId: 1 },
  { categoryId: 2 },
  { categoryId: 3 },
  { categoryId: "5" },
])
const resultEq = await search(db, {
  term: '',
  where: {
    categoryId: { eq: 1 },
  }
}) // Expected 2 results
const resultIn = await search(db, {
  term: '',
  where: {
    categoryId: { in: [1, 3, "5"] },
  }
}) // Expected 4 results

```