### PR TITLE
Adds vector search capabilities to Orama

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the
 
 # Highlighted features
 
-- [Vector Search](https://docs.oramasearch.com/usage/search/vectors)
+- [Vector Search](https://docs.oramasearch.com/usage/search/vector-search)
 - [Search filters](https://docs.oramasearch.com/usage/search/filters)
 - [Facets](https://docs.oramasearch.com/usage/search/facets)
 - [Fields Boosting](https://docs.oramasearch.com/usage/search/fields-boosting)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </h4>
 <br />
 <p align="center">
-  A resilient, innovative and open-source search experience to achieve <br />
+  A resilient, innovative and open-source full-text and vector search experience to achieve <br />
   seamless integration with your infrastructure and data
 </p>
 <br />
@@ -29,10 +29,11 @@
 
 If you need more info, help, or want to provide general feedback on Orama, join
 the
-[Orama Slack channel](https://join.slack.com/t/orama-community/shared_invite/zt-1gzvj0mmt-yJhJ6pnrSGuwqPmPx9uO5Q)
+[Orama Slack channel](https://orama.to/slack)
 
 # Highlighted features
 
+- [Vector Search](https://docs.oramasearch.com/usage/search/vectors)
 - [Search filters](https://docs.oramasearch.com/usage/search/filters)
 - [Facets](https://docs.oramasearch.com/usage/search/facets)
 - [Fields Boosting](https://docs.oramasearch.com/usage/search/fields-boosting)
@@ -78,13 +79,14 @@ Orama is quite simple to use. The first thing to do is to create a new database
 instance and set an indexing schema:
 
 ```js
-import { create, insert, remove, search } from '@orama/orama'
+import { create, insert, remove, search, searchVector } from '@orama/orama'
 
 const db = await create({
   schema: {
     name: 'string',
     description: 'string',
     price: 'number',
+    embedding: 'vector[1536]', // Vector size must be expressed during schema initialization
     meta: {
       rating: 'number',
     },
@@ -104,6 +106,7 @@ await insert(db, {
   name: 'Wireless Headphones',
   description: 'Experience immersive sound quality with these noise-cancelling wireless headphones.',
   price: 99.99,
+  embedding: [...],
   meta: {
     rating: 4.5,
   },
@@ -113,6 +116,7 @@ await insert(db, {
   name: 'Smart LED Bulb',
   description: 'Control the lighting in your home with this energy-efficient smart LED bulb, compatible with most smart home systems.',
   price: 24.99,
+  embedding: [...],
   meta: {
     rating: 4.3,
   },
@@ -122,6 +126,7 @@ await insert(db, {
   name: 'Portable Charger',
   description: 'Never run out of power on-the-go with this compact and fast-charging portable charger for your devices.',
   price: 29.99,
+  embedding: [...],
   meta: {
     rating: 3.6,
   },
@@ -196,6 +201,15 @@ Result:
   ],
   count: 1
 }
+```
+
+If you want to perform a vector search, you can use the `searchVector` function:
+
+```js
+const searchResult = await searchVector(db, {
+  vector: [...], // OpenAI embedding or similar vector to be used as an input
+  property: 'embedding' // Property to search through. Mandatory for vector search
+})
 ```
 
 # Usage with CommonJS

--- a/packages/docs/pages/_meta.json
+++ b/packages/docs/pages/_meta.json
@@ -3,6 +3,10 @@
     "type": "menu",
     "title": "Search Features",
     "items": {
+      "vector-search": {
+        "title": "Vector Search",
+        "href": "/usage/search/vector-search"
+      },
       "typo-tolerance": {
         "title": "Typo Tolerance",
         "href": "/usage/search/introduction#typo-tolerance"

--- a/packages/docs/pages/index.mdx
+++ b/packages/docs/pages/index.mdx
@@ -4,7 +4,7 @@ import { AiFillFileAdd, AiOutlineSearch, AiFillDelete } from 'react-icons/ai'
 
 # Getting Started with Orama
 
-Orama is a fast, batteries-included, full-text search engine entirely written in TypeScript, with zero dependencies. <br /><br />
+Orama is a fast, batteries-included, full-text and vector search engine entirely written in TypeScript, with zero dependencies. <br /><br />
 
 <iframe
   width="100%"

--- a/packages/docs/pages/usage/create.mdx
+++ b/packages/docs/pages/usage/create.mdx
@@ -18,14 +18,15 @@ If you want to learn more and see real-world examples, check out [this blog post
 The `schema` is an object where the keys are the property names and the values are the property types. \
 Orama supports the following types:
 
-| Type        | Description                                                                 | example                                                                     |
-| ----------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `string`    | A string of characters.                                                     | `'Hello world'`                                                             |
-| `number`    | A numeric value, either float or integer.                                   | `42`                                                                        |
-| `boolean`   | A boolean value.                                                            | `true`                                                                      |
-| `string[]`  | An array of strings.                                                        | `['red', 'green', 'blue']`                                                  |
-| `number[]`  | An array of numbers.                                                        | `[42, 91, 28.5]`                                                            |
-| `boolean[]` | An array of booleans.                                                       | `[true, false, false]`                                                      |
+| Type             | Description                                                                 | example                                                                     |
+| ---------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `string`         | A string of characters.                                                     | `'Hello world'`                                                             |
+| `number`         | A numeric value, either float or integer.                                   | `42`                                                                        |
+| `boolean`        | A boolean value.                                                            | `true`                                                                      |
+| `string[]`       | An array of strings.                                                        | `['red', 'green', 'blue']`                                                  |
+| `number[]`       | An array of numbers.                                                        | `[42, 91, 28.5]`                                                            |
+| `boolean[]`      | An array of booleans.                                                       | `[true, false, false]`                                                      |
+| `vector[<size>]` | A vector of numbers to perform vector search on.                            | `[0.403, 0.192, 0.830]`                                                               |
 
 A database can be as simple as:
 
@@ -74,6 +75,29 @@ const movieDB = await create({
   },
 })
 ```
+
+## Vector properties
+
+Since version `1.2.0`, Orama supports vector search. \
+To run vector queries, you first need to initialize a vector property in the schema:
+
+```javascript copy
+const db = await create({
+  schema: {
+    title: 'string',
+    embedding: 'vector[384]',
+  }
+})
+```
+
+Please note that the size of the vector **must** be specified in the schema. \
+The size of the vector is the number of elements that the vector contains, so make sure to specify the correct size, as performing search on vectors of different sizes will result in unpredictable and mostly wrong results.
+
+If you're using vector properties to search through embeddings, we highly recommend using [HuggingFace's](https://huggingface.co/) `gte-small` model, which has a vector size of `384`.
+
+There is a great article written by Supabase explaining why it might be a better option than OpenAI's `text-embedding-ada-002` model: [https://supabase.com/blog/fewer-dimensions-are-better-pgvector](https://supabase.com/blog/fewer-dimensions-are-better-pgvector).
+
+For performance reasons, we recommend using one vector property per database, even though it's possible to have multiple vector properties in the same Orama instance.
 
 ## Instance ID
 

--- a/packages/docs/pages/usage/search/_meta.json
+++ b/packages/docs/pages/usage/search/_meta.json
@@ -1,5 +1,6 @@
 {
   "introduction": "Searching with Orama",
+  "vector-search": "Vector Search",
   "fields-boosting": "Fields boosting",
   "facets": "Facets",
   "filters": "Filters",

--- a/packages/docs/pages/usage/search/vector-search.mdx
+++ b/packages/docs/pages/usage/search/vector-search.mdx
@@ -1,0 +1,73 @@
+import { Callout } from 'nextra-theme-docs'
+
+# Vector Search
+
+Since `v1.2.0`, Orama supports **vector search** natively 🎉.
+
+To perform search through vectors, you need to correctly configure your Orama schema, as described in the [create page](/usage/create).
+
+## Performing Vector Search
+
+To perform vector search, you will need to use a new method called `searchVector`, which can be imported from `@orama/orama`:
+
+```js copy
+import { searchVector } from '@orama/orama'
+```
+
+The APIs are very similar to the ones you already know, but with a few differences:
+
+1. Instead of searching for a `term`, you will need to provide a `vector` to search for.
+2. You will need to specify the vector property you want to search on.
+3. At the time of writing, you can only search through one vector property at a time. If you think that this is too limiting, please open a [feature request](https://github.com/oramasearch/orama/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=) to support multiple vector properties at search-time.
+
+Let's see a full example of how to perform vector search:
+
+```js copy
+import { create, insertMultiple, searchVector } from '@orama/orama'
+
+const db = await create({
+  schema: {
+    title: 'string',        // To make it simple, let's pretend that
+    embedding: 'vector[5]', // we are using a 5-dimensional vector.
+  }
+})
+
+await insertMultiple(db, [
+  { title: 'The Prestige', embedding: [0.938293, 0.284951, 0.348264, 0.948276, 0.564720] },
+  { title: 'Barbie',       embedding: [0.192839, 0.028471, 0.284738, 0.937463, 0.092827] },
+  { title: 'Oppenheimer',  embedding: [0.827391, 0.927381, 0.001982, 0.983821, 0.294841] },
+])
+
+const results = await searchVector(db, {
+  vector: [0.938292, 0.284961, 0.248264, 0.748276, 0.264720],
+  property: 'embedding',
+  similarity: 0.8,      // Minimum similarity. Defaults to `0.8`
+  includeVectors: true, // Defaults to `false`
+  limit: 10,            // Defaults to `10`
+  offset: 0,            // Defaults to `0`
+})
+```
+
+The returning object will be exactly the same as the one we would expect from the default `search` method:
+
+```js
+{
+  count: 1,
+  elapsed: {
+    raw: 25000,
+    formatted: '25ms',
+  },
+  hits: [
+    {
+      id: '1-19238',
+      score: 0.812383129,
+      document: {
+        title: 'The Prestige',
+        embedding: [0.938293, 0.284951, 0.348264, 0.948276, 0.564720],
+      }
+    }
+  ]
+}
+```
+
+Since vectors can be quite large, you can also choose to not include them in the response by setting `includeVectors` to `false` (default behavior).

--- a/packages/orama/README.md
+++ b/packages/orama/README.md
@@ -13,6 +13,7 @@ If you need more info, help, or want to provide general feedback on Orama, join 
 
 # Highlighted features
 
+- [Vector Search](https://docs.oramasearch.com/usage/search/vectors)
 - [Search filters](https://docs.oramasearch.com/usage/search/filters)
 - [Facets](https://docs.oramasearch.com/usage/search/facets)
 - [Fields Boosting](https://docs.oramasearch.com/usage/search/fields-boosting)
@@ -58,13 +59,14 @@ Orama is quite simple to use. The first thing to do is to create a new database
 instance and set an indexing schema:
 
 ```js
-import { create, insert, remove, search } from '@orama/orama'
+import { create, insert, remove, search, searchVector } from '@orama/orama'
 
 const db = await create({
   schema: {
     name: 'string',
     description: 'string',
     price: 'number',
+    embedding: 'vector[1536]', // Vector size must be expressed during schema initialization
     meta: {
       rating: 'number',
     },
@@ -84,6 +86,7 @@ await insert(db, {
   name: 'Wireless Headphones',
   description: 'Experience immersive sound quality with these noise-cancelling wireless headphones.',
   price: 99.99,
+  embedding: [...],
   meta: {
     rating: 4.5,
   },
@@ -91,9 +94,9 @@ await insert(db, {
 
 await insert(db, {
   name: 'Smart LED Bulb',
-  description:
-    'Control the lighting in your home with this energy-efficient smart LED bulb, compatible with most smart home systems.',
+  description: 'Control the lighting in your home with this energy-efficient smart LED bulb, compatible with most smart home systems.',
   price: 24.99,
+  embedding: [...],
   meta: {
     rating: 4.3,
   },
@@ -101,9 +104,9 @@ await insert(db, {
 
 await insert(db, {
   name: 'Portable Charger',
-  description:
-    'Never run out of power on-the-go with this compact and fast-charging portable charger for your devices.',
+  description: 'Never run out of power on-the-go with this compact and fast-charging portable charger for your devices.',
   price: 29.99,
+  embedding: [...],
   meta: {
     rating: 3.6,
   },
@@ -178,6 +181,15 @@ Result:
   ],
   count: 1
 }
+```
+
+If you want to perform a vector search, you can use the `searchVector` function:
+
+```js
+const searchResult = await searchVector(db, {
+  vector: [...], // OpenAI embedding or similar vector to be used as an input
+  property: 'embedding' // Property to search through. Mandatory for vector search
+})
 ```
 
 # Usage with CommonJS

--- a/packages/orama/README.md
+++ b/packages/orama/README.md
@@ -13,7 +13,7 @@ If you need more info, help, or want to provide general feedback on Orama, join 
 
 # Highlighted features
 
-- [Vector Search](https://docs.oramasearch.com/usage/search/vectors)
+- [Vector Search](https://docs.oramasearch.com/usage/search/vector-search)
 - [Search filters](https://docs.oramasearch.com/usage/search/filters)
 - [Facets](https://docs.oramasearch.com/usage/search/facets)
 - [Fields Boosting](https://docs.oramasearch.com/usage/search/fields-boosting)

--- a/packages/orama/src/cjs/index.cts
+++ b/packages/orama/src/cjs/index.cts
@@ -3,6 +3,7 @@ import type { count as esmCount, getByID as esmGetByID } from '../methods/docs.j
 import type { insert as esmInsert, insertMultiple as esminsertMultiple } from '../methods/insert.js'
 import type { remove as esmRemove, removeMultiple as esmRemoveMultiple } from '../methods/remove.js'
 import type { search as esmSearch } from '../methods/search.js'
+import type { searchVector as esmSearchVector } from '../methods/search-vector.js'
 import type { load as esmLoad, save as esmSave } from '../methods/serialization.js'
 import type { update as esmUpdate, updateMultiple as esmUpdateMultiple } from '../methods/update.js'
 
@@ -18,6 +19,7 @@ let _esmSave: typeof esmSave
 let _esmSearch: typeof esmSearch
 let _esmUpdate: typeof esmUpdate
 let _esmUpdateMultiple: typeof esmUpdateMultiple
+let _esmSearchVector: typeof esmSearchVector
 
 export async function count(...args: Parameters<typeof esmCount>): ReturnType<typeof esmCount> {
   if (!_esmCount) {
@@ -131,6 +133,17 @@ export async function updateMultiple(
   }
 
   return _esmUpdateMultiple(...args)
+}
+
+export async function searchVector(
+  ...args: Parameters<typeof esmSearchVector>
+): ReturnType<typeof esmSearchVector> {
+  if (!_esmSearchVector) {
+    const imported = await import('../methods/search-vector.js')
+    _esmSearchVector = imported.searchVector
+  }
+
+  return _esmSearchVector(...args)
 }
 
 export * as components from './components/defaults.cjs'

--- a/packages/orama/src/components/cosine-similarity.ts
+++ b/packages/orama/src/components/cosine-similarity.ts
@@ -1,0 +1,43 @@
+import type { Magnitude, VectorType } from '../types.js'
+
+export type SimilarVector = {
+  id: string
+  score: number
+}
+
+export function getMagnitude(vector: Float32Array, vectorLength: number): number {
+  let magnitude = 0
+  for (let i = 0; i < vectorLength; i++) {
+    magnitude += vector[i] * vector[i]
+  }
+  return Math.sqrt(magnitude)
+}
+
+// @todo: Write plugins for Node and Browsers to use parallel computation for this function
+export function findSimilarVectors(
+  targetVector: Float32Array,
+  vectors: Record<string, [Magnitude, VectorType]>,
+  length: number,
+  threshold = 0.8
+) {
+  const targetMagnitude = getMagnitude(targetVector, length);
+
+  const similarVectors: SimilarVector[] = []
+
+  for (const [vectorId, [magnitude, vector]] of Object.entries(vectors)) {
+    let dotProduct = 0
+
+    for (let i = 0; i < length; i++) {
+      dotProduct += targetVector[i] * vector[i]
+    }
+
+    const similarity = dotProduct / (targetMagnitude * magnitude)
+
+    if (similarity >= threshold) {
+      similarVectors.push({ id: vectorId, score: similarity })
+    }
+  }
+
+  return similarVectors.sort((a, b) => b.score - a.score)
+}
+

--- a/packages/orama/src/components/defaults.ts
+++ b/packages/orama/src/components/defaults.ts
@@ -35,10 +35,9 @@ export async function validateSchema<S extends Schema = Schema>(doc: Document, s
     const typeOfType = typeof type
 
     if (isVectorType(type as string)) {
-      // TODO: validate vector size
-      if (!Array.isArray(value)) {
-        // TODO: run actual validation
-        return undefined
+      const vectorSize = getVectorSize(type as string)
+      if (!Array.isArray(value) || value.length !== vectorSize) {
+        throw createError('INVALID_INPUT_VECTOR', prop, vectorSize, (value as number[]).length)
       }
       continue
     }

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -1,20 +1,20 @@
 import type {
-ArraySearchableType,
-BM25Params,
-ComparisonOperator,
-IIndex,
-Magnitude,
-OpaqueDocumentStore,
-OpaqueIndex,
-Orama,
-ScalarSearchableType,
-Schema,
-SearchableType,
-SearchableValue,
-SearchContext,
-Tokenizer,
-TokenScore,
-VectorType,
+  ArraySearchableType,
+  BM25Params,
+  ComparisonOperator,
+  IIndex,
+  Magnitude,
+  OpaqueDocumentStore,
+  OpaqueIndex,
+  Orama,
+  ScalarSearchableType,
+  Schema,
+  SearchableType,
+  SearchableValue,
+  SearchContext,
+  Tokenizer,
+  TokenScore,
+  VectorType,
 } from '../types.js'
 import { createError } from '../errors.js'
 import {
@@ -586,8 +586,17 @@ export async function load<R = unknown>(sharedInternalDocumentStore: InternalDoc
     indexes[prop] = loadNode(value)
   }
 
-  for (const prop of Object.keys(rawVectorIndexes)) {
-    // TODO: load vector indexes, convert arrays into Float32Arrays
+  for (const idx of Object.keys(rawVectorIndexes)) {
+    const vectors = rawVectorIndexes[idx].vectors
+
+    for (const vec in vectors) {
+      vectors[vec] = [vectors[vec][0], new Float32Array(vectors[vec][1])]
+    }
+
+    vectorIndexes[idx] = {
+      size: rawVectorIndexes[idx].size,
+      vectors,
+    }
   }
 
   return {
@@ -615,9 +624,24 @@ export async function save<R = unknown>(index: Index): Promise<R> {
     fieldLengths,
   } = index
 
+  const vectorIndexesAsArrays: Index['vectorIndexes'] = {}
+
+  for (const idx of Object.keys(vectorIndexes)) {
+    const vectors = vectorIndexes[idx].vectors
+    
+    for (const vec in vectors) {
+      vectors[vec] = [vectors[vec][0], Array.from(vectors[vec][1]) as unknown as Float32Array]
+    }
+
+    vectorIndexesAsArrays[idx] = {
+      size: vectorIndexes[idx].size,
+      vectors
+    }
+  }
+
   return {
     indexes,
-    vectorIndexes,
+    vectorIndexes: vectorIndexesAsArrays,
     searchableProperties,
     searchablePropertiesWithTypes,
     frequencies,

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -1,3 +1,21 @@
+import type {
+ArraySearchableType,
+BM25Params,
+ComparisonOperator,
+IIndex,
+Magnitude,
+OpaqueDocumentStore,
+OpaqueIndex,
+Orama,
+ScalarSearchableType,
+Schema,
+SearchableType,
+SearchableValue,
+SearchContext,
+Tokenizer,
+TokenScore,
+VectorType,
+} from '../types.js'
 import { createError } from '../errors.js'
 import {
   create as avlCreate,
@@ -16,31 +34,16 @@ import {
   Node as RadixNode,
   removeDocumentByWord as radixRemoveDocument,
 } from '../trees/radix.js'
-import {
-  ArraySearchableType,
-  BM25Params,
-  ComparisonOperator,
-  IIndex,
-  OpaqueDocumentStore,
-  OpaqueIndex,
-  Orama,
-  ScalarSearchableType,
-  Schema,
-  SearchableType,
-  SearchableValue,
-  SearchContext,
-  Tokenizer,
-  TokenScore,
-} from '../types.js'
 import { intersect } from '../utils.js'
 import { BM25 } from './algorithms.js'
-import { getInnerType, isArrayType } from './defaults.js'
+import { getInnerType, getVectorSize, isArrayType, isVectorType } from './defaults.js'
 import {
   DocumentID,
   getInternalDocumentId,
   InternalDocumentID,
   InternalDocumentIDStore,
 } from './internal-document-id-store.js'
+import { getMagnitude } from './cosine-similarity.js'
 
 export type FrequencyMap = {
   [property: string]: {
@@ -57,9 +60,17 @@ export type BooleanIndex = {
   false: InternalDocumentID[]
 }
 
+export type VectorIndex = {
+  size: number
+  vectors: {
+    [docID: string]: [Magnitude, VectorType]
+  }
+}
+
 export interface Index extends OpaqueIndex {
   sharedInternalDocumentStore: InternalDocumentIDStore
   indexes: Record<string, RadixNode | AVLNode<number, InternalDocumentID[]> | BooleanIndex>
+  vectorIndexes: Record<string, VectorIndex>
   searchableProperties: string[]
   searchablePropertiesWithTypes: Record<string, SearchableType>
   frequencies: FrequencyMap
@@ -181,6 +192,7 @@ export async function create(
     index = {
       sharedInternalDocumentStore,
       indexes: {},
+      vectorIndexes: {},
       searchableProperties: [],
       searchablePropertiesWithTypes: {},
       frequencies: {},
@@ -200,29 +212,38 @@ export async function create(
       continue
     }
 
-    switch (type) {
-      case 'boolean':
-      case 'boolean[]':
-        index.indexes[path] = { true: [], false: [] }
-        break
-      case 'number':
-      case 'number[]':
-        index.indexes[path] = avlCreate<number, InternalDocumentID[]>(0, [])
-        break
-      case 'string':
-      case 'string[]':
-        index.indexes[path] = radixCreate()
-        index.avgFieldLength[path] = 0
-        index.frequencies[path] = {}
-        index.tokenOccurrences[path] = {}
-        index.fieldLengths[path] = {}
-        break
-      default:
-        throw createError('INVALID_SCHEMA_TYPE', Array.isArray(type) ? 'array' : (type as unknown as string), path)
-    }
+    if (isVectorType(type as string)) {
+      index.searchableProperties.push(path)
+      index.searchablePropertiesWithTypes[path] = (type as SearchableType)
+      index.vectorIndexes[path] = {
+        size: getVectorSize(type as string),
+        vectors: {},
+      }
+    } else {
+      switch (type) {
+        case 'boolean':
+        case 'boolean[]':
+          index.indexes[path] = { true: [], false: [] }
+          break
+        case 'number':
+        case 'number[]':
+          index.indexes[path] = avlCreate<number, InternalDocumentID[]>(0, [])
+          break
+        case 'string':
+        case 'string[]':
+          index.indexes[path] = radixCreate()
+          index.avgFieldLength[path] = 0
+          index.frequencies[path] = {}
+          index.tokenOccurrences[path] = {}
+          index.fieldLengths[path] = {}
+          break
+        default:
+          throw createError('INVALID_SCHEMA_TYPE', Array.isArray(type) ? 'array' : (type as unknown as string), path)
+      }
 
-    index.searchableProperties.push(path)
-    index.searchablePropertiesWithTypes[path] = type
+      index.searchableProperties.push(path)
+      index.searchablePropertiesWithTypes[path] = type
+    }
   }
 
   return index
@@ -276,6 +297,11 @@ export async function insert(
   tokenizer: Tokenizer,
   docsCount: number,
 ): Promise<void> {
+
+  if (isVectorType(schemaType)) {
+    return insertVector(index, prop, value as number[] | Float32Array, id)
+  }
+
   if (!isArrayType(schemaType)) {
     return insertScalar(
       implementation,
@@ -297,6 +323,17 @@ export async function insert(
   for (let i = 0; i < elementsLength; i++) {
     await insertScalar(implementation, index, prop, id, elements[i], innerSchemaType, language, tokenizer, docsCount)
   }
+}
+
+function insertVector(index: Index, prop: string, value: number[] | VectorType, id: DocumentID): void {
+  if (!(value instanceof Float32Array)) {
+    value = new Float32Array(value)
+  }
+  
+  const size = index.vectorIndexes[prop].size
+  const magnitude = getMagnitude(value, size)
+
+  index.vectorIndexes[prop].vectors[id] = [magnitude, value]
 }
 
 async function removeScalar(
@@ -525,6 +562,7 @@ function loadNode(node: RadixNode): RadixNode {
 export async function load<R = unknown>(sharedInternalDocumentStore: InternalDocumentIDStore, raw: R): Promise<Index> {
   const {
     indexes: rawIndexes,
+    vectorIndexes: rawVectorIndexes,
     searchableProperties,
     searchablePropertiesWithTypes,
     frequencies,
@@ -534,6 +572,7 @@ export async function load<R = unknown>(sharedInternalDocumentStore: InternalDoc
   } = raw as Index
 
   const indexes: Index['indexes'] = {}
+  const vectorIndexes: Index['vectorIndexes'] = {}
 
   for (const prop of Object.keys(rawIndexes)) {
     const value = rawIndexes[prop]
@@ -547,9 +586,14 @@ export async function load<R = unknown>(sharedInternalDocumentStore: InternalDoc
     indexes[prop] = loadNode(value)
   }
 
+  for (const prop of Object.keys(rawVectorIndexes)) {
+    // TODO: load vector indexes, convert arrays into Float32Arrays
+  }
+
   return {
     sharedInternalDocumentStore,
     indexes,
+    vectorIndexes,
     searchableProperties,
     searchablePropertiesWithTypes,
     frequencies,
@@ -562,6 +606,7 @@ export async function load<R = unknown>(sharedInternalDocumentStore: InternalDoc
 export async function save<R = unknown>(index: Index): Promise<R> {
   const {
     indexes,
+    vectorIndexes,
     searchableProperties,
     searchablePropertiesWithTypes,
     frequencies,
@@ -572,6 +617,7 @@ export async function save<R = unknown>(index: Index): Promise<R> {
 
   return {
     indexes,
+    vectorIndexes,
     searchableProperties,
     searchablePropertiesWithTypes,
     frequencies,

--- a/packages/orama/src/components/sorter.ts
+++ b/packages/orama/src/components/sorter.ts
@@ -1,5 +1,6 @@
 import { createError } from '../errors.js'
 import { ISorter, OpaqueSorter, Orama, Schema, SorterConfig, SorterParams, SortType, SortValue } from '../types.js'
+import { isVectorType } from './defaults.js'
 import {
   DocumentID,
   getInternalDocumentId,
@@ -70,26 +71,28 @@ function innerCreate(
       continue
     }
 
-    switch (type) {
-      case 'boolean':
-      case 'number':
-      case 'string':
-        sorter.sortableProperties.push(path)
-        sorter.sortablePropertiesWithTypes[path] = type
-        sorter.sorts[path] = {
-          docs: new Map(),
-          orderedDocsToRemove: new Map(),
-          orderedDocs: [],
-          type: type,
-        }
-        break
-      case 'boolean[]':
-      case 'number[]':
-      case 'string[]':
-        // We don't allow to sort by arrays
-        continue
-      default:
-        throw createError('INVALID_SORT_SCHEMA_TYPE', Array.isArray(type) ? 'array' : (type as unknown as string), path)
+    if (!isVectorType(type as string)) {
+      switch (type) {
+        case 'boolean':
+        case 'number':
+        case 'string':
+          sorter.sortableProperties.push(path)
+          sorter.sortablePropertiesWithTypes[path] = type
+          sorter.sorts[path] = {
+            docs: new Map(),
+            orderedDocsToRemove: new Map(),
+            orderedDocs: [],
+            type: type,
+          }
+          break
+        case 'boolean[]':
+        case 'number[]':
+        case 'string[]':
+          // We don't allow to sort by arrays
+          continue
+        default:
+          throw createError('INVALID_SORT_SCHEMA_TYPE', Array.isArray(type) ? 'array' : (type as unknown as string), path)
+      }
     }
   }
 

--- a/packages/orama/src/errors.ts
+++ b/packages/orama/src/errors.ts
@@ -31,7 +31,7 @@ const errors = {
   UNKNOWN_FILTER_PROPERTY: `Unknown filter property "%s".`,
   INVALID_VECTOR_SIZE: `Vector size must be a number greater than 0. Got "%s" instead.`,
   INVALID_VECTOR_VALUE: `Vector value must be a number greater than 0. Got "%s" instead.`,
-  WRONG_VECTOR_SIZE: `Vector size must be %s. Got a vector of %s dimensions instead.`
+  INVALID_INPUT_VECTOR: `Property "%s" was declared as a %s-dimentional vector, but got a %s-dimentional vector instead.\nInput vectors must be of the size declared in the schema, as calculating similarity between vectors of different sizes can lead to unexpected results.`,
 }
 
 export type ErrorCode = keyof typeof errors

--- a/packages/orama/src/errors.ts
+++ b/packages/orama/src/errors.ts
@@ -29,6 +29,9 @@ const errors = {
   UNKNOWN_GROUP_BY_PROPERTY: `Unknown groupBy property "%s".`,
   INVALID_GROUP_BY_PROPERTY: `Invalid groupBy property "%s". Allowed types: "%s", but given "%s".`,
   UNKNOWN_FILTER_PROPERTY: `Unknown filter property "%s".`,
+  INVALID_VECTOR_SIZE: `Vector size must be a number greater than 0. Got "%s" instead.`,
+  INVALID_VECTOR_VALUE: `Vector value must be a number greater than 0. Got "%s" instead.`,
+  WRONG_VECTOR_SIZE: `Vector size must be %s. Got a vector of %s dimensions instead.`
 }
 
 export type ErrorCode = keyof typeof errors

--- a/packages/orama/src/index.ts
+++ b/packages/orama/src/index.ts
@@ -3,6 +3,7 @@ export { count, getByID } from './methods/docs.js'
 export { insert, insertMultiple } from './methods/insert.js'
 export { remove, removeMultiple } from './methods/remove.js'
 export { search } from './methods/search.js'
+export { searchVector } from './methods/search-vector.js'
 export { load, save } from './methods/serialization.js'
 export { update, updateMultiple } from './methods/update.js'
 

--- a/packages/orama/src/methods/insert.ts
+++ b/packages/orama/src/methods/insert.ts
@@ -1,4 +1,4 @@
-import { isArrayType } from '../components.js'
+import { isArrayType, isVectorType } from '../components.js'
 import { runMultipleHook, runSingleHook } from '../components/hooks.js'
 import { trackInsertion } from '../components/sync-blocking-checker.js'
 import { createError } from '../errors.js'
@@ -43,6 +43,11 @@ async function innerInsert(orama: Orama, doc: Document, language?: string, skipH
 
     const actualType = typeof value
     const expectedType = indexablePropertiesWithTypes[key]
+
+    if (isVectorType(expectedType) && Array.isArray(value)) {
+      // @todo: Validate vector type. It should be of a given length and contain only floats.
+      continue
+    }
 
     if (isArrayType(expectedType) && Array.isArray(value)) {
       continue

--- a/packages/orama/src/methods/search-vector.ts
+++ b/packages/orama/src/methods/search-vector.ts
@@ -22,7 +22,7 @@ export async function searchVector(orama: Orama, params: SearchVectorParams): Pr
   const vectors = vectorIndex.vectors as Record<string, [Magnitude, VectorType]>
 
   if (vector.length !== vectorSize) {
-    throw createError('WRONG_VECTOR_SIZE', vectorSize, vector.length)
+    throw createError('INVALID_INPUT_VECTOR', property, vectorSize, vector.length)
   }
 
   if (!(vector instanceof Float32Array)) {

--- a/packages/orama/src/methods/search-vector.ts
+++ b/packages/orama/src/methods/search-vector.ts
@@ -43,7 +43,6 @@ export async function searchVector(orama: Orama, params: SearchVectorParams): Pr
     const doc = (orama.data.docs as any).docs[originalID]
 
     if (doc) {
-      // TODO: manage multiple vector properties
       if (!includeVectors) {
         doc[property] = null
       }

--- a/packages/orama/src/methods/search-vector.ts
+++ b/packages/orama/src/methods/search-vector.ts
@@ -1,0 +1,71 @@
+import type { Magnitude, Orama, Result, Results, VectorType } from '../types.js'
+import { getNanosecondsTime, formatNanoseconds } from '../utils.js'
+import { findSimilarVectors } from '../components/cosine-similarity.js'
+import { getInternalDocumentId } from '../components/internal-document-id-store.js'
+import { createError } from '../errors.js'
+
+export type SearchVectorParams = {
+  vector: number[] | Float32Array
+  property: string
+  similarity?: number
+  limit?: number
+  offset?: number
+  includeVectors?: boolean
+}
+
+export async function searchVector(orama: Orama, params: SearchVectorParams): Promise<Results> {
+  const timeStart = await getNanosecondsTime()
+  let { vector } = params
+  const { property, limit = 10, offset = 0, includeVectors = false } = params
+  const vectorIndex = (orama.data.index as any).vectorIndexes[property]
+  const vectorSize = vectorIndex.size
+  const vectors = vectorIndex.vectors as Record<string, [Magnitude, VectorType]>
+
+  if (vector.length !== vectorSize) {
+    throw createError('WRONG_VECTOR_SIZE', vectorSize, vector.length)
+  }
+
+  if (!(vector instanceof Float32Array)) {
+    vector = new Float32Array(vector)
+  }
+
+  const results = findSimilarVectors(vector, vectors, vectorSize, params.similarity)
+
+  const docs = Array.from({ length: limit })
+
+  for (let i = 0; i < limit; i++) {
+    const result = results[i + offset]
+    if (!result) {
+      break
+    }
+
+    const originalID = getInternalDocumentId(orama.internalDocumentIDStore, result.id)
+    const doc = (orama.data.docs as any).docs[originalID]
+
+    if (doc) {
+      // TODO: manage multiple vector properties
+      if (!includeVectors) {
+        doc[property] = null
+      }
+
+      const newDoc = {
+        id: result.id,
+        score: result.score,
+        document: doc
+      }
+      docs[i] = newDoc
+    }
+  }
+
+  const timeEnd = await getNanosecondsTime()
+  const elapsedTime = timeEnd - timeStart
+
+  return {
+    count: results.length,
+    hits: docs.filter(Boolean) as Result[],
+    elapsed: {
+      raw: Number(elapsedTime),
+      formatted: await formatNanoseconds(elapsedTime),
+    }
+  }
+}

--- a/packages/orama/src/methods/search.ts
+++ b/packages/orama/src/methods/search.ts
@@ -1,15 +1,4 @@
-import { prioritizeTokenScores } from '../components/algorithms.js'
-import { getFacets } from '../components/facets.js'
-import { intersectFilteredIDs } from '../components/filters.js'
-import { getGroups } from '../components/groups.js'
-import { runAfterSearch } from '../components/hooks.js'
-import {
-  getDocumentIdFromInternalId,
-  getInternalDocumentId,
-  InternalDocumentID,
-} from '../components/internal-document-id-store.js'
-import { createError } from '../errors.js'
-import {
+import type {
   BM25Params,
   IndexMap,
   Orama,
@@ -28,6 +17,17 @@ import {
   SearchableValue,
   TokenScore,
 } from '../types.js'
+import { prioritizeTokenScores } from '../components/algorithms.js'
+import { getFacets } from '../components/facets.js'
+import { intersectFilteredIDs } from '../components/filters.js'
+import { getGroups } from '../components/groups.js'
+import { runAfterSearch } from '../components/hooks.js'
+import {
+  getDocumentIdFromInternalId,
+  getInternalDocumentId,
+  InternalDocumentID,
+} from '../components/internal-document-id-store.js'
+import { createError } from '../errors.js'
 import { getNanosecondsTime, getNested, sortTokenScorePredicate } from '../utils.js'
 
 const defaultBM25Params: BM25Params = {

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -22,12 +22,16 @@ export interface Schema extends Record<string, SearchableType | Schema> {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Document extends Record<string, SearchableValue | Document | unknown> {}
 
+export type Magnitude = number
+export type Vector = `vector[${number}]`
+export type VectorType = Float32Array
+
 export type ScalarSearchableType = 'string' | 'number' | 'boolean'
-export type ArraySearchableType = 'string[]' | 'number[]' | 'boolean[]'
+export type ArraySearchableType = 'string[]' | 'number[]' | 'boolean[]' | Vector
 export type SearchableType = ScalarSearchableType | ArraySearchableType
 
 export type ScalarSearchableValue = string | number | boolean
-export type ArraySearchableValue = string[] | number[] | boolean[]
+export type ArraySearchableValue = string[] | number[] | boolean[] | VectorType
 export type SearchableValue = ScalarSearchableValue | ArraySearchableValue
 
 export type SortType = 'string' | 'number' | 'boolean'

--- a/packages/orama/tests/cosine-similarity.test.ts
+++ b/packages/orama/tests/cosine-similarity.test.ts
@@ -1,0 +1,63 @@
+import t from 'tap'
+import { findSimilarVectors, getMagnitude } from '../src/components/cosine-similarity.js'
+
+function toF32(vector: number[]): Float32Array {
+  return new Float32Array(vector)
+}
+
+t.test('cosine similarity', t => {
+  t.plan(2)
+
+  t.test('getMagnitude', t => {
+    t.plan(1)
+
+    t.test('should return the magnitude of a vector', t => {
+      t.plan(3)
+
+      {
+        const vector = toF32([1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        const magnitude = getMagnitude(vector, vector.length)
+  
+        t.equal(magnitude, 1)
+      }
+
+      {
+        const vector = toF32([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        const magnitude = getMagnitude(vector, vector.length)
+
+        t.equal(magnitude, Math.sqrt(10))
+      }
+
+      {
+        const vector = toF32([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        const magnitude = getMagnitude(vector, vector.length)
+
+        t.equal(magnitude, Math.sqrt(385))
+      }
+
+    })
+  })
+
+  t.test('findSimilarVectors', t => {
+    t.plan(1)
+
+    t.test('should return the most similar vectors', t => {
+      t.plan(3)
+
+      const targetVector = toF32([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+      const vectors = {
+        '1': [1, toF32([1, 0, 0, 0, 0, 0, 0, 0, 0, 0])],
+        '2': [1, toF32([0, 1, 1, 1, 1, 1, 1, 1, 1, 1])],
+        '3': [1, toF32([0, 0, 1, 1, 1, 1, 1, 1, 1, 1])]
+      }
+
+      // @ts-expect-error - @todo: fix types
+      const similarVectors = findSimilarVectors(targetVector, vectors, targetVector.length)
+
+      t.same(similarVectors.length, 2)
+      t.same(similarVectors[0].id, '2')
+      t.same(similarVectors[1].id, '3')
+    })
+
+  })
+})

--- a/packages/orama/tests/create.test.ts
+++ b/packages/orama/tests/create.test.ts
@@ -2,7 +2,7 @@ import t from 'tap'
 import { create } from '../src/methods/create.js'
 import { Components } from '../src/types.js'
 
-t.only('create method', t => {
+t.test('create method', t => {
   t.test('should provide an unique ID for the instance', async t => {
     t.plan(3)
 

--- a/packages/orama/tests/search-vector.test.ts
+++ b/packages/orama/tests/search-vector.test.ts
@@ -1,0 +1,65 @@
+import t from 'tap'
+import { create, insertMultiple, searchVector } from '../src/index.js'
+
+t.test('create', t => {
+  t.plan(2)
+
+  t.test('should create a vector instance', async t => {
+    const db = await create({
+      schema: {
+        title: 'string',
+        description: 'string',
+        embedding: 'vector[1536]' 
+      }
+    })
+  
+    t.ok(db, 'db instance created')
+  })
+
+  t.test('should throw an error if no vector size is provided', async t => {
+    try {
+      await create({
+        schema: {
+          title: 'string',
+          description: 'string',
+          // @ts-expect-error error case
+          embedding: 'vector[]'
+        }
+      })
+    } catch (err) {
+      t.ok(err, 'error thrown')
+    }
+  })
+
+})
+
+t.test('searchVector', t => {
+  t.plan(1)
+
+  t.test('should return the most similar vectors', async t => {
+    t.plan(3)
+
+    const db = await create({
+      schema: {
+        vector: 'vector[5]'
+      }
+    })
+
+    await insertMultiple(db, [
+      { vector: [1, 1, 1, 1, 1] },
+      { vector: [0, 1, 1, 1, 1] },
+      { vector: [0, 0, 1, 1, 1] }
+    ])
+
+    const results = await searchVector(db, {
+      vector: [1, 1, 1, 1, 1],
+      property: 'vector',
+      includeVectors: true
+    })
+
+    t.same(results.count, 2)
+    t.same(results.hits[0].document.vector, [1, 1, 1, 1, 1])
+    t.same(results.hits[1].document.vector, [0, 1, 1, 1, 1])
+
+  })
+})

--- a/packages/orama/tests/search-vector.test.ts
+++ b/packages/orama/tests/search-vector.test.ts
@@ -2,7 +2,7 @@ import t from 'tap'
 import { create, insertMultiple, searchVector } from '../src/index.js'
 
 t.test('create', t => {
-  t.plan(2)
+  t.plan(3)
 
   t.test('should create a vector instance', async t => {
     const db = await create({
@@ -31,10 +31,24 @@ t.test('create', t => {
     }
   })
 
+  t.test('should throw an error if vector size is not a number', async t => {
+    try {
+      await create({
+        schema: {
+          title: 'string',
+          description: 'string',
+          // @ts-expect-error error case
+          embedding: 'vector[foo]'
+        }
+      })
+    } catch (err) {
+      t.ok(err, 'error thrown')
+    }
+  })
 })
 
 t.test('searchVector', t => {
-  t.plan(1)
+  t.plan(4)
 
   t.test('should return the most similar vectors', async t => {
     t.plan(3)
@@ -62,4 +76,106 @@ t.test('searchVector', t => {
     t.same(results.hits[1].document.vector, [0, 1, 1, 1, 1])
 
   })
+
+  t.test('should search through nested properties', async t => {
+    t.plan(3)
+
+    const db = await create({
+      schema: {
+        title: 'string',
+        vectors: {
+          embedding: 'vector[5]'
+        }
+      }
+    })
+
+    await insertMultiple(db, [
+      { title: 'foo', vectors: { embedding: [1, 1, 1, 1, 1] } },
+      { title: 'bar', vectors: { embedding: [0, 1, 1, 1, 1] } },
+      { title: 'baz', vectors: { embedding: [0, 0, 1, 1, 1] } }
+    ])
+
+    const results = await searchVector(db, {
+      vector: [1, 1, 1, 1, 1],
+      property: 'vectors.embedding',
+      includeVectors: true
+    })
+
+    t.same(results.count, 2)
+    t.same((results.hits[0].document as any).vectors.embedding, [1, 1, 1, 1, 1])
+    t.same((results.hits[1].document as any).vectors.embedding, [0, 1, 1, 1, 1])
+  })
+
+  t.test('should search through deeply nested properties', async t => {
+    t.plan(3)
+
+    const db = await create({
+      schema: {
+        title: 'string',
+        deeply: {
+          nested: {
+            vectors: 'vector[5]'
+          }
+        }
+      }
+    })
+
+    await insertMultiple(db, [
+      { title: 'foo', deeply: { nested: { vectors: [1, 1, 1, 1, 1] } } },
+      { title: 'bar', deeply: { nested: { vectors: [0, 1, 1, 1, 1] } } },
+      { title: 'baz', deeply: { nested: { vectors: [0, 0, 1, 1, 1] } } }
+    ])
+
+    const results = await searchVector(db, {
+      vector: [1, 1, 1, 1, 1],
+      property: 'deeply.nested.vectors',
+      includeVectors: true
+    })
+
+    t.same(results.count, 2)
+    t.same((results.hits[0].document as any).deeply.nested.vectors, [1, 1, 1, 1, 1])
+    t.same((results.hits[1].document as any).deeply.nested.vectors, [0, 1, 1, 1, 1])
+  })
+
+  t.test('should be able to work on multiple vector properties at creation time', async t => {
+    t.plan(7)
+
+    const db = await create({
+      schema: {
+        title: 'string',
+        vectors: {
+          embedding: 'vector[5]',
+          embedding_2: 'vector[6]'
+        }
+      }
+    })
+
+    await insertMultiple(db, [
+      { title: 'foo', vectors: { embedding: [1, 1, 1, 1, 1], embedding_2: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2] } },
+      { title: 'bar', vectors: { embedding: [0, 1, 1, 1, 1], embedding_2: [0.2, .02, 0.1, 0.1, 0.1, 0.1] } },
+      { title: 'baz', vectors: { embedding: [0, 0, 1, 1, 1], embedding_2: [0.2, 0.2, 0.21, 0.21, 0.21, 0.21] } }
+    ])
+
+    const results1 = await searchVector(db, {
+      vector: [1, 1, 1, 1, 1],
+      property: 'vectors.embedding',
+      includeVectors: true
+    })
+
+    const results2 = await searchVector(db, {
+      vector: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2],
+      property: 'vectors.embedding_2',
+      includeVectors: true
+    })
+
+    t.same(results1.count, 2)
+    t.same((results1.hits[0].document as any).vectors.embedding, [1, 1, 1, 1, 1])
+    t.same((results1.hits[1].document as any).vectors.embedding, [0, 1, 1, 1, 1])
+
+    t.same(results2.count, 3)
+    t.same((results2.hits[0].document as any).vectors.embedding_2, [0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
+    t.same((results2.hits[1].document as any).vectors.embedding_2, [0.2, 0.2, 0.21, 0.21, 0.21, 0.21])
+    t.same((results2.hits[2].document as any).vectors.embedding_2, [0.2, .02, 0.1, 0.1, 0.1, 0.1])
+  })
+
 })

--- a/packages/orama/tests/sort.test.ts
+++ b/packages/orama/tests/sort.test.ts
@@ -512,7 +512,7 @@ t.test('disabled', async t => {
   t.end()
 })
 
-t.only('search with sortBy should be consistent ignoring the insert order', async t => {
+t.test('search with sortBy should be consistent ignoring the insert order', async t => {
   const docs = [
     { id: '5' },
     { id: '2', number: 5 },

--- a/packages/plugin-data-persistence/src/server.ts
+++ b/packages/plugin-data-persistence/src/server.ts
@@ -118,9 +118,9 @@ export async function getDefaultFileName(format: PersistenceFormat, runtime?: Ru
   /* c8 ignore next 3 */
   if (runtime === 'deno') {
     // @ts-expect-error Deno is only available in Deno
-    dbName = Deno.env.get('LYRA_DB_NAME') ?? DEFAULT_DB_NAME
+    dbName = Deno.env.get('ORAMA_DB_NAME') ?? DEFAULT_DB_NAME
   } else {
-    dbName = process?.env?.LYRA_DB_NAME ?? DEFAULT_DB_NAME
+    dbName = process?.env?.ORAMA_DB_NAME ?? DEFAULT_DB_NAME
   }
 
   return `${dbName}.${extension}`

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,5 +1,4 @@
 import { spawn } from 'node:child_process'
-import { cp } from 'node:fs/promises'
 import { resolve, relative } from 'node:path'
 
 const rootDir = process.cwd()


### PR DESCRIPTION
This PR introduces vector search capabilities in Orama. This will be part of Orama `v1.2.0`, the next major release.

## New Vector API

Orama adds support for Vector search by adding a new datatype: `vector[<size>]`:

```js
import { create } from '@orama/orama'

const db = await create({
  schema: {
    text: 'string',
    embedding: 'vector[1536]' // <--- vector size is mandatory here. OpenAI embeddings, for instance, have 1536 dimensions. 
  }
})
```

After you create your Orama instance, you can insert and search for vectors using the new `searchVector` function:

```js
import { create, insert, searchVector } from '@orama/orama'

const db = await create({
  schema: {
    text: 'string',
    myVector: 'vector[5]'
  }
})

await insert(db, { text: 'foo', myVector: [1, 0, 0, 0, 0] })
await insert(db, { text: 'bar', myVector: [0, 0, 0, 0, 0] })
await insert(db, { text: 'baz', myVector: [1, 1, 1, 1, 1] })

const results = await searchVector(db, {
  vector: [1, 0, 0, 0, 0], // Your input vector
  property: 'myVector' // Property to search through is mandatory with the "searchVector" function
})
```