### PR TITLE
set tokenizer language during load

### DIFF
--- a/packages/orama/src/methods/serialization.ts
+++ b/packages/orama/src/methods/serialization.ts
@@ -1,3 +1,4 @@
+import { Language } from '../index.js'
 import { Orama } from '../types.js'
 
 export interface RawData {
@@ -5,6 +6,7 @@ export interface RawData {
   index: unknown
   docs: unknown
   sorting: unknown
+  language: Language
 }
 
 export async function load(orama: Orama, raw: RawData): Promise<void> {
@@ -12,6 +14,7 @@ export async function load(orama: Orama, raw: RawData): Promise<void> {
   orama.data.index = await orama.index.load(orama.internalDocumentIDStore, raw.index)
   orama.data.docs = await orama.documentsStore.load(orama.internalDocumentIDStore, raw.docs)
   orama.data.sorting = await orama.sorter.load(orama.internalDocumentIDStore, raw.sorting)
+  orama.tokenizer.language = raw.language
 }
 
 export async function save(orama: Orama): Promise<RawData> {
@@ -20,5 +23,6 @@ export async function save(orama: Orama): Promise<RawData> {
     index: await orama.index.save(orama.data.index),
     docs: await orama.documentsStore.save(orama.data.docs),
     sorting: await orama.sorter.save(orama.data.sorting),
+    language: orama.tokenizer.language,
   }
 }


### PR DESCRIPTION
Hi @micheleriva, this is a simple proposal that fixes https://github.com/oramasearch/orama/issues/467.

Not sure if you wanted to persist more of the tokenizer config.