### PR TITLE
fix: Fixed copy and maximum call stack exceeded

### DIFF
--- a/packages/orama/src/methods/search.ts
+++ b/packages/orama/src/methods/search.ts
@@ -179,7 +179,7 @@ export async function search<AggValue = Result[]>(
         // Lookup
         const scoreList = await orama.index.search(context, index, prop, term)
 
-        context.indexMap[prop][term].push(...scoreList)
+        context.indexMap[prop][term].concat(scoreList)
       }
 
       const docIds = context.indexMap[prop]

--- a/packages/orama/src/trees/avl.ts
+++ b/packages/orama/src/trees/avl.ts
@@ -111,7 +111,7 @@ export function rangeSearch<K, V>(node: Node<K, V>, min: K, max: K): V {
     }
 
     if (node.key >= min && node.key <= max) {
-      result.push(...(node.value as V[]))
+      result.concat(node.value as V[])
     }
 
     if (node.key < max) {
@@ -139,11 +139,11 @@ export function greaterThan<K, V>(node: Node<K, V>, key: K, inclusive = false): 
     }
 
     if (inclusive && node.key >= key) {
-      result.push(...(node.value as V[]))
+      result.concat((node.value as V[]))
     }
 
     if (!inclusive && node.key > key) {
-      result.push(...(node.value as V[]))
+      result.concat((node.value as V[]))
     }
 
     traverse(node.left as Node<K, V>)
@@ -170,11 +170,11 @@ export function lessThan<K, V>(node: Node<K, V>, key: K, inclusive = false): V {
     }
 
     if (inclusive && node.key <= key) {
-      result.push(...(node.value as V[]))
+      result.concat((node.value as V[]))
     }
 
     if (!inclusive && node.key < key) {
-      result.push(...(node.value as V[]))
+      result.concat((node.value as V[]))
     }
 
     traverse(node.left as Node<K, V>)

--- a/packages/orama/tests/insert.test.ts
+++ b/packages/orama/tests/insert.test.ts
@@ -321,7 +321,7 @@ t.test('insert method', t => {
         { boolean: {} },
         { boolean: [] },
       ]
-      invalidDocuments.push(...invalidDocuments.map(d => ({ inner: { ...d } })))
+      invalidDocuments.concat(invalidDocuments.map(d => ({ inner: { ...d } })))
       for (const doc of invalidDocuments) {
         await t.rejects(insert(db, doc as Document))
       }


### PR DESCRIPTION
Fixed problem with Maximum call stack exceeded and improve performance on huge data with concat

Reproduce:
```js
import { create, insertMultiple } from '@orama/orama'

const originalInstance = await create({
  schema: {
    id: 'number',
    people: 'number',
    location: {
      latitude: 'number',
      longitude: 'number'
    },
    rating: 'number',
    price: 'number',
    flags: {
      isBoolean: 'boolean'
    }
  },
})

const data = []
for (let index = 0; index < 500_000; index++) {
  data.push({
    refID: String(index),
    people: Math.round(Math.random() * 100),
    location: {
      latitude: Math.round(Math.random() * 180 - 90),
      longitude: Math.round(Math.random() * 180 - 90)
    },
    rating: Math.round(Math.random() * 5),
    price: Math.round(Math.random() * 25_000),
    flags: {
      isBoolean: Math.random() > 0.5
    }
  })
}
await insertMultiple(originalInstance, data)
```
