### PR TITLE
Add `saveWithHighlight` and `loadWithHighlight`

### DIFF
--- a/packages/plugin-match-highlight/src/commonjs.cts
+++ b/packages/plugin-match-highlight/src/commonjs.cts
@@ -4,7 +4,9 @@ import type { Orama } from '@orama/orama'
 import type {
   afterInsert as esmAfterInsert,
   OramaWithHighlight,
-  searchWithHighlight as esmSearchWithHighlight
+  searchWithHighlight as esmSearchWithHighlight,
+  saveWithHighlight as esmSaveWithHighlight,
+  loadWithHighlight as esmLoadWithHighlight
   // @ts-expect-error Ignore broken resolution - This errors when using tsconfig.cjs.json
 } from './index.js'
 
@@ -17,6 +19,8 @@ export type RequireCallback = (err: Error | undefined, orama?: OramaPluginMatchH
 
 let _esmAfterInsert: typeof esmAfterInsert
 let _esmSearchWithHighlight: typeof esmSearchWithHighlight
+let _esmSaveWithHighlight: typeof saveWithHighlight
+let _esmLoadWithHighlight: typeof loadWithHighlight
 
 export async function afterInsert(
   this: Orama | OramaWithHighlight,
@@ -39,6 +43,28 @@ export async function searchWithHighlight(
   }
 
   return _esmSearchWithHighlight(...args)
+}
+
+export async function saveWithHighlight(
+  ...args: Parameters<typeof esmSaveWithHighlight>
+): ReturnType<typeof esmSaveWithHighlight> {
+  if (!_esmSaveWithHighlight) {
+    const imported = await import('./index.js')
+    _esmSaveWithHighlight = imported.saveWithHighlight
+  }
+
+  return _esmSaveWithHighlight(...args)
+}
+
+export async function loadWithHighlight(
+  ...args: Parameters<typeof esmLoadWithHighlight>
+): ReturnType<typeof esmLoadWithHighlight> {
+  if (!_esmLoadWithHighlight) {
+    const imported = await import('./index.js')
+    _esmLoadWithHighlight = imported.loadWithHighlight
+  }
+
+  return _esmLoadWithHighlight(...args)
 }
 
 export function requireOramaPluginMatchHighlight(callback: RequireCallback): void {

--- a/packages/plugin-match-highlight/src/index.ts
+++ b/packages/plugin-match-highlight/src/index.ts
@@ -1,4 +1,16 @@
-import { Document, Language, Orama, Result, Results, Schema, search, SearchParams } from '@orama/orama'
+import {
+  RawData,
+  Document,
+  Language,
+  Orama,
+  Result,
+  Results,
+  Schema,
+  search,
+  load,
+  SearchParams,
+  save
+} from '@orama/orama'
 
 export interface Position {
   start: number
@@ -11,6 +23,10 @@ export type OramaWithHighlight = Orama & {
 
 export type SearchResultWithHighlight = Results & {
   hits: (Result & { positions: Position[] })[]
+}
+
+export type RawDataWithPositions = RawData & {
+  positions: Record<string, Record<string, Record<string, Position[]>>>
 }
 
 export async function afterInsert(orama: Orama | OramaWithHighlight, id: string): Promise<void> {
@@ -93,4 +109,18 @@ export async function searchWithHighlight(
 
   // @ts-ignore
   return result
+}
+
+export async function saveWithHighlight(orama: Orama): Promise<RawDataWithPositions> {
+  const data = await save(orama)
+
+  return {
+    ...data,
+    positions: (orama as OramaWithHighlight).data.positions
+  }
+}
+
+export async function loadWithHighlight(orama: OramaWithHighlight, raw: RawDataWithPositions): Promise<void> {
+  await load(orama, raw)
+  orama.data.positions = raw.positions
 }


### PR DESCRIPTION
See here for context: https://github.com/oramasearch/orama/issues/446#issuecomment-1693672265

New to the project so apologies if this isn't the right approach. It's extending the native `save()` and `load()` since `"positions"` is not present and included in either. It does the raise question of how this would work if you had multiple plugins that needed to extend the base `Orama` object?

Another approach could be by passing an array of the attributes you wanted the base `save()` and `load()` to include.

Fixes #446 