### PR TITLE
Tokenize skip properties

### DIFF
--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -476,8 +476,10 @@ export async function searchByWhereClause<I extends OpaqueIndex, D extends Opaqu
 
       for (const raw of [operation].flat()) {
         const term = await context.tokenizer.tokenize(raw, context.language, param)
-        const filteredIDsResults = radixFind(idx, { term: term[0], exact: true })
-        filtersMap[param].push(...Object.values(filteredIDsResults).flat())
+        for (const t of term) {
+          const filteredIDsResults = radixFind(idx, { term: t, exact: true })
+          filtersMap[param].push(...Object.values(filteredIDsResults).flat())
+        }
       }
 
       continue

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -214,7 +214,7 @@ export async function create(
 
     if (isVectorType(type as string)) {
       index.searchableProperties.push(path)
-      index.searchablePropertiesWithTypes[path] = (type as SearchableType)
+      index.searchablePropertiesWithTypes[path] = type as SearchableType
       index.vectorIndexes[path] = {
         size: getVectorSize(type as string),
         vectors: {},
@@ -297,7 +297,6 @@ export async function insert(
   tokenizer: Tokenizer,
   docsCount: number,
 ): Promise<void> {
-
   if (isVectorType(schemaType)) {
     return insertVector(index, prop, value as number[] | Float32Array, id)
   }
@@ -329,7 +328,7 @@ function insertVector(index: Index, prop: string, value: number[] | VectorType, 
   if (!(value instanceof Float32Array)) {
     value = new Float32Array(value)
   }
-  
+
   const size = index.vectorIndexes[prop].size
   const magnitude = getMagnitude(value, size)
 
@@ -630,14 +629,14 @@ export async function save<R = unknown>(index: Index): Promise<R> {
 
   for (const idx of Object.keys(vectorIndexes)) {
     const vectors = vectorIndexes[idx].vectors
-    
+
     for (const vec in vectors) {
       vectors[vec] = [vectors[vec][0], Array.from(vectors[vec][1]) as unknown as Float32Array]
     }
 
     vectorIndexesAsArrays[idx] = {
       size: vectorIndexes[idx].size,
-      vectors
+      vectors,
     }
   }
 

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -530,6 +530,7 @@ export type DefaultTokenizerConfig = {
   stemming?: boolean
   stemmer?: Stemmer
   stemmerSkipProperties?: string | string[]
+  tokenizeSkipProperties?: string | string[]
   stopWords?: boolean | string[] | ((stopWords: string[]) => string[] | Promise<string[]>)
   allowDuplicates?: boolean
 }

--- a/packages/orama/tests/tokenizeSkipProperties.test.ts
+++ b/packages/orama/tests/tokenizeSkipProperties.test.ts
@@ -1,0 +1,120 @@
+import * as t from 'tap'
+import { Orama, create, getByID, insert, search } from '../src/index.js'
+
+t.test('tokenizeSkipProperties', t => {
+  t.test('skipProperties', async t => {
+    const [db, id1, id2, id3, id4] = await createSimpleDB(true)
+
+    const result = await search(db, {
+      where: {
+        'meta.finish': 'black matte',
+      },
+    })
+
+    t.ok(result.elapsed)
+    t.ok(result.elapsed.raw)
+    t.ok(result.elapsed.formatted)
+    t.equal(result.count, 1)
+    t.equal(result.hits[0].id, id1)
+
+    t.end()
+  })
+
+  t.test('noSkipProperties', async t => {
+    const [db, id1, id2, id3, id4] = await createSimpleDB(false)
+
+    const result = await search(db, {
+      where: {
+        'meta.finish': 'black matte',
+      },
+    })
+
+    t.ok(result.elapsed)
+    t.ok(result.elapsed.raw)
+    t.ok(result.elapsed.formatted)
+    t.equal(result.count, 3)
+
+    for (const id of [id1, id2, id4]) {
+      t.ok(result.hits.find(d => d.id === id))
+    }
+
+    t.end()
+  })
+  t.end()
+})
+
+async function createSimpleDB(skipProperties: boolean): Promise<[Orama, string, string, string, string]> {
+  let db: Orama
+  if (skipProperties) {
+    db = await create({
+      schema: {
+        name: 'string',
+        rating: 'number',
+        price: 'number',
+        meta: {
+          sales: 'number',
+          finish: 'string',
+        },
+      },
+      components: {
+        tokenizer: {
+          tokenizeSkipProperties: ['meta.finish'],
+        },
+      },
+    })
+  } else {
+    db = await create({
+      schema: {
+        name: 'string',
+        rating: 'number',
+        price: 'number',
+        meta: {
+          sales: 'number',
+          finish: 'string',
+        },
+      },
+    })
+  }
+
+  const id1 = await insert(db, {
+    name: 'super coffee maker',
+    rating: 5,
+    price: 900,
+    meta: {
+      sales: 100,
+      finish: 'black matte',
+    },
+  })
+
+  const id2 = await insert(db, {
+    name: 'washing machine',
+    rating: 5,
+    price: 900,
+    meta: {
+      sales: 100,
+      finish: 'gloss black',
+    },
+  })
+
+  const id3 = await insert(db, {
+    name: 'coffee maker',
+    rating: 3,
+    price: 30,
+    meta: {
+      sales: 25,
+      finish: 'gloss blue',
+    },
+  })
+
+  const id4 = await insert(db, {
+    name: 'coffee maker deluxe',
+    rating: 5,
+    price: 45,
+    meta: {
+      sales: 25,
+      finish: 'blue matte',
+    },
+  })
+
+  return [db, id1, id2, id3, id4]
+}


### PR DESCRIPTION
I want to used facet search but many of the values we have are multi-word-token (ie. "black matte") that needs to be searched without tokenization, not only stemming but no split at all.

I added a new optionnal parameter that replicate the stemmingSkipProperties that was already in place.

If a property is matched, then no splitting occurs on the matching prop.