### PR TITLE
Implements enum[]

### DIFF
--- a/packages/docs/pages/usage/create.mdx
+++ b/packages/docs/pages/usage/create.mdx
@@ -22,6 +22,7 @@ Orama supports the following types:
 | `string[]`       | An array of strings.                                                        | `['red', 'green', 'blue']`                                                  |
 | `number[]`       | An array of numbers.                                                        | `[42, 91, 28.5]`                                                            |
 | `boolean[]`      | An array of booleans.                                                       | `[true, false, false]`                                                      |
+| `enum`           | An enum value.                                                              | `['drama', 'crime', 'war']`                                                 |
 | `vector[<size>]` | A vector of numbers to perform vector search on.                            | `[0.403, 0.192, 0.830]`                                                     |
 
 A database can be as simple as:

--- a/packages/docs/pages/usage/create.mdx
+++ b/packages/docs/pages/usage/create.mdx
@@ -22,7 +22,7 @@ Orama supports the following types:
 | `string[]`       | An array of strings.                                                        | `['red', 'green', 'blue']`                                                  |
 | `number[]`       | An array of numbers.                                                        | `[42, 91, 28.5]`                                                            |
 | `boolean[]`      | An array of booleans.                                                       | `[true, false, false]`                                                      |
-| `enum`           | An enum value.                                                              | `['drama', 'crime', 'war']`                                                 |
+| `enum[]`         | An array of enums.                                                          | `['comedy', 'action', 'romance']`                                           |
 | `vector[<size>]` | A vector of numbers to perform vector search on.                            | `[0.403, 0.192, 0.830]`                                                     |
 
 A database can be as simple as:

--- a/packages/docs/pages/usage/search/facets.mdx
+++ b/packages/docs/pages/usage/search/facets.mdx
@@ -178,6 +178,22 @@ In the search result, `boolean` facets will be returned as an `object` with the 
 }
 ```
 
+### Enum facets
+
+If a property is specified as `enum` in the schema, no configuration is required.
+In the search result, `enum` facets will be returned as an `object` with the following properties:
+
+```js
+{
+  count: 9,            // Total number of values
+  values: {
+    'Action': 4,        // Number of documents that have this value
+    'Adventure': 3,     // Number of documents that have this value
+    'Comedy': 2,        // Number of documents that have this value
+  }
+}
+```
+
 ### How facets works on array fields
 
 Orama treats each array element as a single element of the facet:
@@ -209,3 +225,4 @@ const results = await search(db, {
   }
 }
 ```
+

--- a/packages/docs/pages/usage/search/filters.mdx
+++ b/packages/docs/pages/usage/search/filters.mdx
@@ -126,7 +126,6 @@ The enum properties support the following operators:
 
 The enum properties support the following operators:
 
-| Operator        | Description                        | Example                                       |
-| ---------       | ------------------------------     | ---------------------------------             |
-| `contains`      | Contains the given value           | `genre: { contains: 'drama' }`                |
-| `intersects`    | Intersects with the given array    | `genre: { intersects: ['drama', 'horror'] }`  |
+| Operator           | Description                             | Example                                            |
+| ---------          | ------------------------------          | ---------------------------------                  |
+| `containsAll`      | Contains all the given values           | `genre: { containsAll: ['comedy', 'action'] }`     |

--- a/packages/docs/pages/usage/search/filters.mdx
+++ b/packages/docs/pages/usage/search/filters.mdx
@@ -113,10 +113,20 @@ const results = await search(db, {
 
 ## Enum operators
 
-The numeric properties support the following operators:
+The enum properties support the following operators:
 
 | Operator  | Description                        | Example                                 |
 | --------- | ------------------------------     | ---------------------------------       |
 | `eq`      | Equal to                           | `genre: { eq: 'drama' }`                |
 | `in`      | Contained in the given array       | `genre: { in: ['drama', 'horror'] }`    |
 | `nin`     | Not contained in the given array   | `genre: { nin: ['commedy'] }`           |
+
+
+## Enum[] operators
+
+The enum properties support the following operators:
+
+| Operator        | Description                        | Example                                       |
+| ---------       | ------------------------------     | ---------------------------------             |
+| `contains`      | Contains the given value           | `genre: { contains: 'drama' }`                |
+| `intersects`    | Intersects with the given array    | `genre: { intersects: ['drama', 'horror'] }`  |

--- a/packages/orama/src/components/defaults.ts
+++ b/packages/orama/src/components/defaults.ts
@@ -46,6 +46,15 @@ export async function validateSchema<T extends AnyOrama, ResultDocument extends 
     if (type === 'enum' && (typeof value === 'string' || typeof value === 'number')) {
       continue
     }
+    if (type === 'enum[]' && Array.isArray(value)) {
+      const valueLength = value.length
+      for (let i = 0; i < valueLength; i++) {
+        if (typeof value[i] !== 'string' && typeof value[i] !== 'number') {
+          return prop + '.' + i
+        }
+      }
+      continue
+    }
 
     if (isVectorType(type)) {
       const vectorSize = getVectorSize(type)
@@ -100,12 +109,14 @@ const IS_ARRAY_TYPE: Record<SearchableType, boolean> = {
   'string[]': true,
   'number[]': true,
   'boolean[]': true,
+  'enum[]': true,
 }
 
 const INNER_TYPE: Record<ArraySearchableType, ScalarSearchableType> = {
   'string[]': 'string',
   'number[]': 'number',
   'boolean[]': 'boolean',
+  'enum[]': 'enum',
 }
 
 export function isVectorType(type: unknown): type is Vector {

--- a/packages/orama/src/components/facets.ts
+++ b/packages/orama/src/components/facets.ts
@@ -1,3 +1,4 @@
+import { createError } from '../errors.js'
 import type {
   AnyOrama,
   FacetResult,
@@ -75,19 +76,23 @@ export async function getFacets<T extends AnyOrama>(
           break
         }
         case 'boolean':
+        case 'enum':
         case 'string': {
-          calculateBooleanOrStringFacet(facets[facet].values, facetValue as string | boolean, propertyType)
+          calculateBooleanStringOrEnumFacet(facets[facet].values, facetValue as string | boolean | number, propertyType)
           break
         }
         case 'boolean[]':
+        case 'enum[]':
         case 'string[]': {
           const alreadyInsertedValues = new Set<string>()
           const innerType = propertyType === 'boolean[]' ? 'boolean' : 'string'
-          for (const v of facetValue as Array<string | boolean>) {
-            calculateBooleanOrStringFacet(facets[facet].values, v, innerType, alreadyInsertedValues)
+          for (const v of facetValue as Array<string | boolean | number>) {
+            calculateBooleanStringOrEnumFacet(facets[facet].values, v, innerType, alreadyInsertedValues)
           }
           break
         }
+        default:
+          throw createError('FACET_NOT_SUPPORTED', propertyType)
       }
     }
   }
@@ -137,10 +142,10 @@ function calculateNumberFacet(
   }
 }
 
-function calculateBooleanOrStringFacet(
+function calculateBooleanStringOrEnumFacet(
   values: Record<string, number>,
-  facetValue: string | boolean,
-  propertyType: 'string' | 'boolean',
+  facetValue: string | boolean | number,
+  propertyType: 'string' | 'boolean' | 'enum',
   alreadyInsertedValues?: Set<string>,
 ) {
   // String or boolean based facets

--- a/packages/orama/src/components/facets.ts
+++ b/packages/orama/src/components/facets.ts
@@ -11,6 +11,8 @@ import type {
 } from '../types.js'
 import { getNested } from '../utils.js'
 
+type FacetValue = string | boolean | number
+
 function sortingPredicate(order: FacetSorting = 'desc', a: [string, number], b: [string, number]) {
   if (order.toLowerCase() === 'asc') {
     return a[1] - b[1]
@@ -78,7 +80,7 @@ export async function getFacets<T extends AnyOrama>(
         case 'boolean':
         case 'enum':
         case 'string': {
-          calculateBooleanStringOrEnumFacet(facets[facet].values, facetValue as string | boolean | number, propertyType)
+          calculateBooleanStringOrEnumFacet(facets[facet].values, facetValue as FacetValue, propertyType)
           break
         }
         case 'boolean[]':
@@ -86,7 +88,7 @@ export async function getFacets<T extends AnyOrama>(
         case 'string[]': {
           const alreadyInsertedValues = new Set<string>()
           const innerType = propertyType === 'boolean[]' ? 'boolean' : 'string'
-          for (const v of facetValue as Array<string | boolean | number>) {
+          for (const v of facetValue as Array<FacetValue>) {
             calculateBooleanStringOrEnumFacet(facets[facet].values, v, innerType, alreadyInsertedValues)
           }
           break
@@ -144,7 +146,7 @@ function calculateNumberFacet(
 
 function calculateBooleanStringOrEnumFacet(
   values: Record<string, number>,
-  facetValue: string | boolean | number,
+  facetValue: FacetValue,
   propertyType: 'string' | 'boolean' | 'enum',
   alreadyInsertedValues?: Set<string>,
 ) {

--- a/packages/orama/src/components/sorter.ts
+++ b/packages/orama/src/components/sorter.ts
@@ -83,6 +83,9 @@ function innerCreate<T extends AnyOrama>(
           }
           break
         case 'enum':
+          // We don't allow to sort by enums
+          continue
+        case 'enum[]':
         case 'boolean[]':
         case 'number[]':
         case 'string[]':

--- a/packages/orama/src/errors.ts
+++ b/packages/orama/src/errors.ts
@@ -33,6 +33,7 @@ const errors = {
   INVALID_VECTOR_VALUE: `Vector value must be a number greater than 0. Got "%s" instead.`,
   INVALID_INPUT_VECTOR: `Property "%s" was declared as a %s-dimentional vector, but got a %s-dimentional vector instead.\nInput vectors must be of the size declared in the schema, as calculating similarity between vectors of different sizes can lead to unexpected results.`,
   WRONG_SEARCH_PROPERTY_TYPE: `Property "%s" is not searchable. Only "string" properties are searchable.`,
+  FACET_NOT_SUPPORTED: `Facet doens't support the type "%s".`,
 }
 
 export type ErrorCode = keyof typeof errors

--- a/packages/orama/src/methods/insert.ts
+++ b/packages/orama/src/methods/insert.ts
@@ -63,7 +63,7 @@ async function innerInsert<T extends AnyOrama>(
       continue
     }
 
-    if (expectedType === 'enum' && (actualType === 'string' || actualType === 'number')) {
+    if ((expectedType === 'enum' || expectedType === 'enum[]') && (actualType === 'string' || actualType === 'number')) {
       continue
     }
 

--- a/packages/orama/src/trees/flat.ts
+++ b/packages/orama/src/trees/flat.ts
@@ -1,5 +1,6 @@
 import { InternalDocumentID } from "../components/internal-document-id-store.js"
 import { EnumArrComparisonOperator, EnumComparisonOperator, Nullable, ScalarSearchableValue } from "../types.js"
+import { intersect } from "../utils.js"
 
 export interface FlatTree {
   numberToDocumentId: Map<ScalarSearchableValue, InternalDocumentID[]>
@@ -103,20 +104,10 @@ export function filterArr(root: FlatTree, operation: EnumArrComparisonOperator):
 
   const operationType = operationKeys[0] as keyof EnumArrComparisonOperator
   switch (operationType) {
-    case 'contains': {
-      const value = operation[operationType]!
-      return root.numberToDocumentId.get(value) ?? []
-    }
-    case 'intersects': {
+    case 'containsAll': {
       const values = operation[operationType]!
-      const result: InternalDocumentID[] = []
-      for (const v of values) {
-        const ids = root.numberToDocumentId.get(v)
-        if (ids) {
-          result.push(...ids)
-        }
-      }
-      return result
+      const ids = values.map((value) => root.numberToDocumentId.get(value) ?? [])
+      return intersect(ids)
     }
   }
 

--- a/packages/orama/src/trees/flat.ts
+++ b/packages/orama/src/trees/flat.ts
@@ -1,5 +1,5 @@
 import { InternalDocumentID } from "../components/internal-document-id-store.js"
-import { EnumComparisonOperator, Nullable, ScalarSearchableValue } from "../types.js"
+import { EnumArrComparisonOperator, EnumComparisonOperator, Nullable, ScalarSearchableValue } from "../types.js"
 
 export interface FlatTree {
   numberToDocumentId: Map<ScalarSearchableValue, InternalDocumentID[]>
@@ -83,6 +83,35 @@ export function filter(root: FlatTree, operation: EnumComparisonOperator): Inter
           continue
         }
         const ids = root.numberToDocumentId.get(key)
+        if (ids) {
+          result.push(...ids)
+        }
+      }
+      return result
+    }
+  }
+
+  throw new Error('Invalid operation')
+}
+
+export function filterArr(root: FlatTree, operation: EnumArrComparisonOperator): InternalDocumentID[] {
+  const operationKeys = Object.keys(operation)
+
+  if (operationKeys.length !== 1) {
+    throw new Error('Invalid operation')
+  }
+
+  const operationType = operationKeys[0] as keyof EnumArrComparisonOperator
+  switch (operationType) {
+    case 'contains': {
+      const value = operation[operationType]!
+      return root.numberToDocumentId.get(value) ?? []
+    }
+    case 'intersects': {
+      const values = operation[operationType]!
+      const result: InternalDocumentID[] = []
+      for (const v of values) {
+        const ids = root.numberToDocumentId.get(v)
         if (ids) {
           result.push(...ids)
         }

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -24,6 +24,8 @@ export type SchemaTypes<Value> = Value extends 'string'
   ? number[]
   : Value extends 'enum'
   ? string | number
+  : Value extends 'enum[]'
+  ? (string | number)[]
   : // eslint-disable-next-line @typescript-eslint/no-unused-vars
   Value extends `vector[${number}]`
   ? number[]
@@ -144,8 +146,7 @@ export type EnumComparisonOperator = {
 }
 
 export type EnumArrComparisonOperator = {
-  contains?: string | number | boolean,
-  intersects ?: (string | number | boolean)[]
+  containsAll ?: (string | number | boolean)[]
 }
 
 /**

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -71,7 +71,7 @@ export type Vector = `vector[${number}]`
 export type VectorType = Float32Array
 
 export type ScalarSearchableType = 'string' | 'number' | 'boolean' | 'enum'
-export type ArraySearchableType = 'string[]' | 'number[]' | 'boolean[]' | Vector
+export type ArraySearchableType = 'string[]' | 'number[]' | 'boolean[]' | 'enum[]' | Vector
 
 export type SearchableType = ScalarSearchableType | ArraySearchableType
 
@@ -141,6 +141,11 @@ export type EnumComparisonOperator = {
   eq?: string | number | boolean
   in?: (string | number | boolean)[]
   nin?: (string | number | boolean)[]
+}
+
+export type EnumArrComparisonOperator = {
+  contains?: string | number | boolean,
+  intersects ?: (string | number | boolean)[]
 }
 
 /**
@@ -306,7 +311,7 @@ export type SearchParams<T extends AnyOrama, ResultDocument = TypedDocument<T>> 
    *  }
    * });
    */
-  where?: Partial<Record<LiteralUnion<T['schema']>, boolean | string | string[] | ComparisonOperator | EnumComparisonOperator>>
+  where?: Partial<Record<LiteralUnion<T['schema']>, boolean | string | string[] | ComparisonOperator | EnumComparisonOperator | EnumArrComparisonOperator>>
 
   /**
    * Threshold to use for refining the search results.
@@ -554,7 +559,7 @@ export interface IIndex<I extends AnyIndexStore> {
   searchByWhereClause<T extends AnyOrama, ResultDocument = TypedDocument<T>>(
     context: SearchContext<T, ResultDocument>,
     index: I,
-    filters: Partial<Record<LiteralUnion<T['schema']>, boolean | string | string[] | ComparisonOperator | EnumComparisonOperator>>,
+    filters: Partial<Record<LiteralUnion<T['schema']>, boolean | string | string[] | ComparisonOperator | EnumComparisonOperator | EnumArrComparisonOperator>>,
   ): SyncOrAsyncValue<InternalDocumentID[]>
 
   getSearchableProperties(index: I): SyncOrAsyncValue<string[]>

--- a/packages/orama/tests/enum.test.ts
+++ b/packages/orama/tests/enum.test.ts
@@ -250,3 +250,236 @@ t.test('enum', async t => {
 
   t.end()
 })
+
+
+t.test('enum[]', async t => {
+
+  t.test('filter', async t => {
+    const db = await create({
+      schema: {
+        tags: 'enum[]',
+      },
+    })
+
+    const cGreenBlue = await insert(db, {
+      tags: ['green', 'blue'],
+    })
+    const [cGreen, cBlue, cWhite] = await insertMultiple(db, [
+      { tags: ['green'] },
+      { tags: ['blue'] },
+      { tags: ['white'] },
+    ])
+
+    const testsContains = [
+      { value: 'green', expected: [cGreenBlue, cGreen] },
+      { value: 'blue', expected: [cGreenBlue, cBlue] },
+      { value: 'white', expected: [cWhite] },
+      { value: 'unknown', expected: [] },
+    ]
+    t.test('contains', async t => {
+      for (const { value, expected } of testsContains) {
+        t.test(`contains: "${value}"`, async t => {
+          const result = await search(db, {
+            term: '',
+            where: {
+              tags: { contains: value },
+            }
+          })
+          t.equal(result.hits.length, expected.length)
+          t.strictSame(result.hits.map(h => h.id), expected)
+
+          t.end()
+        })
+      }
+    })
+
+    const testsIntersects = [
+      { values: ['green'], expected: [cGreenBlue, cGreen] },
+      { values: ['blue'], expected: [cGreenBlue, cBlue] },
+      { values: ['white'], expected: [cWhite] },
+      { values: ['unknown'], expected: [] },
+      { values: ['green', 'blue', 'white'], expected: [cGreenBlue, cGreen, cBlue, cWhite] },
+      { values: ['green', 'blue', 'white', 'unknown'], expected: [cGreenBlue, cGreen, cBlue, cWhite] },
+      { values: ['white', 'unknown'], expected: [cWhite] },
+      { values: [], expected: [] },
+    ]
+    t.test('intersects', async t => {
+      for (const { values, expected } of testsIntersects) {
+        t.test(`intersects: "${values}"`, async t => {
+          const result = await search(db, {
+            term: '',
+            where: {
+              tags: { intersects: values },
+            }
+          })
+          t.equal(result.hits.length, expected.length)
+          t.strictSame(result.hits.map(h => h.id), expected)
+
+          t.end()
+        })
+      }
+    })
+
+    t.test('eq operator shouldn\'t allowed', async t => {
+      await t.rejects(search(db, {
+        term: '',
+        where: {
+          tags: { eq: 'green' },
+        }
+      }), 'aa')
+
+      t.end()
+    })
+
+    t.test('in operator shouldn\'t allowed', async t => {
+      await t.rejects(search(db, {
+        term: '',
+        where: {
+          tags: { in: ['green'] },
+        }
+      }), 'aa')
+
+      t.end()
+    })
+
+    t.test('in operator shouldn\'t allowed', async t => {
+      await t.rejects(search(db, {
+        term: '',
+        where: {
+          tags: { nin: ['green'] },
+        }
+      }), 'aa')
+
+      t.end()
+    })
+
+    t.end()
+  })
+
+  t.test(`remove document works fine`, async t => {
+    const db = await create({
+      schema: {
+        tags: 'enum[]',
+      },
+    })
+    const c1 = await insert(db, { tags: ['green'] })
+    const c11 = await insert(db, { tags: ['blue'] })
+
+    const result1 = await search(db, {
+      term: '',
+      where: { tags: { intersects: ['green', 'blue'] }, }
+    })
+    t.equal(result1.hits.length, 2)
+    t.strictSame(result1.hits.map(h => h.id), [c1, c11])
+
+    await remove(db, c1)
+
+    const result2 = await search(db, {
+      term: '',
+      where: { tags: { intersects: ['green', 'blue'] }, }
+    })
+    t.equal(result2.hits.length, 1)
+    t.strictSame(result2.hits.map(h => h.id), [c11])
+
+    t.end()
+  })
+
+  t.test(`still serializable`, async t => {
+    const db1 = await create({
+      schema: {
+        tags: 'enum[]',
+      },
+    })
+    const [c1, c11, c2, c3, c5] = await insertMultiple(db1, [
+      { tags: ['green'] },
+      { tags: ['green', 'blue'] },
+      { tags: ['orange'] },
+      { tags: ['purple'] },
+      { tags: ['black'] },
+    ])
+
+    const dump = await save(db1)
+
+    const db2 = await create({
+      schema: {
+        tags: 'enum[]',
+      },
+    })
+    await load(db2, dump)
+
+    const result1 = await search(db2, {
+      term: '',
+      where: {
+        tags: { contains: 'green' },
+      }
+    })
+    t.equal(result1.hits.length, 2)
+    t.strictSame(result1.hits.map(h => h.id), [c1, c11])
+
+    const result2 = await search(db2, {
+      term: '',
+      where: {
+        tags: { intersects: ['green', 'blue', 'orange', 'purple', 'black'] },
+      }
+    })
+    t.equal(result2.hits.length, 5)
+    t.strictSame(result2.hits.map(h => h.id), [c1, c11, c2, c3, c5])
+
+    t.end()
+  })
+
+  t.test(`complex example`, async t => {
+    const filmDb = await create({
+      schema: {
+        title: 'string',
+        year: 'number',
+        tags: 'enum[]',
+      },
+    })
+    const [, , , c4] = await insertMultiple(filmDb, [
+      { title: 'The Shawshank Redemption', year: 1994, tags: ['drama', 'crime'] },
+      { title: 'The Godfather', year: 1972, tags: ['drama', 'crime'] },
+      { title: 'The Dark Knight', year: 2008, tags: ['action', 'adventure'] },
+      { title: 'Schindler\'s List', year: 1993, tags: ['war', 'drama '] },
+      { title: 'The Lord of the Rings: The Return of the King', year: 2003, tags: ['fantasy', 'adventure'] },
+    ])
+
+    const result1 = await search(filmDb, {
+      term: 'l',
+    })
+    t.equal(result1.hits.length, 2)
+
+    const result2 = await search(filmDb, {
+      term: 'l',
+      where: {
+        tags: { contains: 'war' },
+      }
+    })
+    t.equal(result2.hits.length, 1)
+    t.strictSame(result2.hits.map(h => h.id), [c4])
+
+    const result3 = await search(filmDb, {
+      term: 'l',
+      where: {
+        year: { gt: 2000 },
+        tags: { contains: 'war' },
+      }
+    })
+    t.equal(result3.hits.length, 0)
+    t.strictSame(result3.hits.map(h => h.id), [])
+
+    const result4 = await search(filmDb, {
+      term: 'l',
+      where: {
+        year: { lte: 2000 },
+        tags: { contains: 'war' },
+      }
+    })
+    t.equal(result4.hits.length, 1)
+    t.strictSame(result4.hits.map(h => h.id), [c4])
+
+    t.end()
+  })
+
+  t.end()
+})

--- a/packages/orama/tests/facets.test.ts
+++ b/packages/orama/tests/facets.test.ts
@@ -160,35 +160,6 @@ t.test('facets', t => {
     t.same(results.facets?.price.values['6-8'], 1)
   })
 
-  t.test('', async t => {
-
-    const db = await create({
-      schema: {
-        foo: 'number',
-      },
-    })
-
-    await insertMultiple(db, [
-      { foo: 1 },
-      { foo: 2 },
-      { foo: 3 },
-      { foo: 4 },
-    ])
-
-
-    const results = await search(db, {
-      term: '',
-      facets: {
-        foo: {},
-      },
-    })
-
-    console.log(results)
-
-
-    t.end()
-  })
-
   t.test('should work with `enum` and `enum[]`', async t => {
 
     const db = await create({

--- a/packages/orama/tests/facets.test.ts
+++ b/packages/orama/tests/facets.test.ts
@@ -160,6 +160,35 @@ t.test('facets', t => {
     t.same(results.facets?.price.values['6-8'], 1)
   })
 
+  t.test('', async t => {
+
+    const db = await create({
+      schema: {
+        foo: 'number',
+      },
+    })
+
+    await insertMultiple(db, [
+      { foo: 1 },
+      { foo: 2 },
+      { foo: 3 },
+      { foo: 4 },
+    ])
+
+
+    const results = await search(db, {
+      term: '',
+      facets: {
+        foo: {},
+      },
+    })
+
+    console.log(results)
+
+
+    t.end()
+  })
+
   t.test('should work with `enum` and `enum[]`', async t => {
 
     const db = await create({

--- a/packages/plugin-data-persistence/test/index.test.ts
+++ b/packages/plugin-data-persistence/test/index.test.ts
@@ -25,38 +25,42 @@ async function generateTestDBInstance() {
     schema: {
       quote: 'string',
       author: 'string',
-      genre: 'enum'
+      genre: 'enum',
+      colors: 'enum[]',
     }
   })
 
   await insert(db, {
     quote: 'I am a great programmer',
     author: 'Bill Gates',
-    genre: 'tech'
+    genre: 'tech',
+    colors: ['red', 'blue']
   })
 
   await insert(db, {
     quote: 'Be yourself; everyone else is already taken.',
     author: 'Oscar Wilde',
-    genre: 'life'
+    genre: 'life',
+    colors: ['red', 'green']
   })
 
   await insert(db, {
     quote: "I have not failed. I've just found 10,000 ways that won't work.",
     author: 'Thomas A. Edison',
-    genre: 'tech'
+    genre: 'tech',
+    colors: ['red', 'blue']
   })
 
   await insert(db, {
     quote: 'The only way to do great work is to love what you do.',
-    author: 'Steve Jobs'
+    author: 'Steve Jobs',
   })
 
   return db
 }
 
 t.test('binary persistence', t => {
-  t.plan(4)
+  t.plan(5)
 
   t.test('should generate a persistence file on the disk with random name', async t => {
     t.plan(2)
@@ -208,10 +212,34 @@ t.test('binary persistence', t => {
 
     await rm(path)
   })
+
+  t.test('should continue to work with `enum[]`', async t => {
+    t.plan(1)
+
+    const db = await generateTestDBInstance()
+    const q1 = await search(db, {
+      where: {
+        colors: { intersects: ['green'] }
+      }
+    })
+
+    const path = await persistToFile(db, 'binary', 'test.dpack')
+    const db2 = await restoreFromFile('binary', 'test.dpack')
+
+    const qp1 = await search(db2, {
+      where: {
+        colors: { intersects: ['green'] }
+      }
+    })
+
+    t.same(q1.hits, qp1.hits)
+
+    await rm(path)
+  })
 })
 
 t.test('json persistence', t => {
-  t.plan(4)
+  t.plan(5)
 
   t.test('should generate a persistence file on the disk with random name and json format', async t => {
     t.plan(2)
@@ -341,10 +369,34 @@ t.test('json persistence', t => {
 
     await rm(path)
   })
+
+  t.test('should continue to work with `enum[]`', async t => {
+    t.plan(1)
+
+    const db = await generateTestDBInstance()
+    const q1 = await search(db, {
+      where: {
+        colors: { intersects: ['green'] }
+      }
+    })
+
+    const path = await persistToFile(db, 'json', 'test.json')
+    const db2 = await restoreFromFile('json', 'test.json')
+
+    const qp1 = await search(db2, {
+      where: {
+        colors: { intersects: ['green'] }
+      }
+    })
+
+    t.same(q1.hits, qp1.hits)
+
+    await rm(path)
+  })
 })
 
 t.test('dpack persistence', t => {
-  t.plan(3)
+  t.plan(4)
 
   t.test('should generate a persistence file on the disk with random name and dpack format', async t => {
     t.plan(2)
@@ -430,6 +482,30 @@ t.test('dpack persistence', t => {
     const qp1 = await search(db2, {
       where: {
         genre: { eq: 'way' }
+      }
+    })
+
+    t.same(q1.hits, qp1.hits)
+
+    await rm(path)
+  })
+
+  t.test('should continue to work with `enum[]`', async t => {
+    t.plan(1)
+
+    const db = await generateTestDBInstance()
+    const q1 = await search(db, {
+      where: {
+        colors: { intersects: ['green'] }
+      }
+    })
+
+    const path = await persistToFile(db, 'dpack', 'test.dpack')
+    const db2 = await restoreFromFile('dpack', 'test.dpack')
+
+    const qp1 = await search(db2, {
+      where: {
+        colors: { intersects: ['green'] }
       }
     })
 

--- a/packages/plugin-data-persistence/test/index.test.ts
+++ b/packages/plugin-data-persistence/test/index.test.ts
@@ -219,7 +219,7 @@ t.test('binary persistence', t => {
     const db = await generateTestDBInstance()
     const q1 = await search(db, {
       where: {
-        colors: { intersects: ['green'] }
+        colors: { containsAll: ['green'] }
       }
     })
 
@@ -228,7 +228,7 @@ t.test('binary persistence', t => {
 
     const qp1 = await search(db2, {
       where: {
-        colors: { intersects: ['green'] }
+        colors: { containsAll: ['green'] }
       }
     })
 
@@ -376,7 +376,7 @@ t.test('json persistence', t => {
     const db = await generateTestDBInstance()
     const q1 = await search(db, {
       where: {
-        colors: { intersects: ['green'] }
+        colors: { containsAll: ['green'] }
       }
     })
 
@@ -385,7 +385,7 @@ t.test('json persistence', t => {
 
     const qp1 = await search(db2, {
       where: {
-        colors: { intersects: ['green'] }
+        colors: { containsAll: ['green'] }
       }
     })
 
@@ -496,7 +496,7 @@ t.test('dpack persistence', t => {
     const db = await generateTestDBInstance()
     const q1 = await search(db, {
       where: {
-        colors: { intersects: ['green'] }
+        colors: { containsAll: ['green'] }
       }
     })
 
@@ -505,7 +505,7 @@ t.test('dpack persistence', t => {
 
     const qp1 = await search(db2, {
       where: {
-        colors: { intersects: ['green'] }
+        colors: { containsAll: ['green'] }
       }
     })
 


### PR DESCRIPTION
With this PR, I want to introduce the `enum[]` as the follower of #458

So,
```javascript
const db = await create({
  schema: {
   colors: 'enum[]',
  },
})
await insertMultiple(db, [
  {colors: ['green', 'red'] },
  {colors: ['green'] },
  {colors: ['blue', 'white'] },
])

const resultContains = await search(db, {
  term: '',
  where: {
    colors: { contains: 'green' },
  }
}) // Expected 2 results: 1° and 2°
const resultIntersects = await search(db, {
  term: '',
  where: {
    colors: { intersects: ['red', 'blue'] },
  }
}) // Expected 2 results: 1° and 3°
```

This PR introduces `contains`, and `intersects` operators because they are more appropriate for arrays.

- [x] implementation
- [x] documentation
- [x] tests
- [x] facets for `enum` and `enum[]`
- [ ] feedback