### PR TITLE
fix(plugin-match-highlight): `SearchResultWithHighlight` type improvement

### DIFF
--- a/packages/plugin-match-highlight/src/index.ts
+++ b/packages/plugin-match-highlight/src/index.ts
@@ -1,14 +1,17 @@
 import {
-  AnyDocument, AnyOrama,
+  AnyDocument,
+  AnyOrama,
   Language,
   RawData,
-  Result, Results,
-  SearchParams, TypedDocument,
+  Result,
+  Results,
+  SearchParams,
+  TypedDocument,
   load,
   save,
   search
 } from '@orama/orama'
-import { boundedLevenshtein } from '@orama/orama/internals';
+import { boundedLevenshtein } from '@orama/orama/internals'
 
 export interface Position {
   start: number
@@ -19,8 +22,12 @@ export type OramaWithHighlight<T extends AnyOrama> = T & {
   data: { positions: Record<string, Record<string, Record<string, Position[]>>> }
 }
 
-export type SearchResultWithHighlight<ResultDocument> = Results<ResultDocument> & {
-  hits: (Result<ResultDocument> & { positions: Record<string, Record<string, Position[]>> })[]
+export type ResultWithPositions<ResultDocument> = Result<ResultDocument> & {
+  positions: Record<string, Record<string, Position[]>>
+}
+
+export type SearchResultWithHighlight<ResultDocument> = Omit<Results<ResultDocument>, 'hits'> & {
+  hits: ResultWithPositions<ResultDocument>[]
 }
 
 export type RawDataWithPositions = RawData & {
@@ -138,6 +145,6 @@ export async function saveWithHighlight<T extends AnyOrama>(orama: T): Promise<R
 }
 
 export async function loadWithHighlight<T extends AnyOrama>(orama: T, raw: RawDataWithPositions): Promise<void> {
-  await load(orama, raw);
-  (orama as OramaWithHighlight<T>).data.positions = raw.positions
+  await load(orama, raw)
+  ;(orama as OramaWithHighlight<T>).data.positions = raw.positions
 }


### PR DESCRIPTION
The current way the `SearchResultWithHighlight` type is constructed ends up losing type info if you use an array method to iterate over `hits`. I made a [TypeScript playground demo](https://www.typescriptlang.org/play?#code/FAehAIBcE8AcFMDO4BmAnA9gW3AIgAIZoCGWxIRpxuwMC4ASkgK4A2kAPACIYDGzWeADtIAPnABecAG9g4eeACWAEwBc4RJDSKhAcwDcchYl5F46oQIBG8NIYXhlfAcMjqe-QSMMBfQ3XhGFnZEbmcvMUkZI3lTZhELa1t7BQALRUhEdSZENk4PFxFRAG0AXRT5MHB4VmJYRHg1cABRWvrGgBVFQQrwKpRiXnhMgH51ADFB4Zy88AAfcHjleBQdRt6q3UxmerHwAHFt2Bn2MM9XcQWllbXlX0NQCADkdGw8QhIyEFhWZl0dAC0ZEgvFSAPSulSrEUkMgNB0kFsAyG4AAChhEBlFBghNEHJpiGg3OBLFgbHYYuBWMJdJBUokyclgD5gI9wABhZhoNCuKBwcxsgLgADK8EJoJOkAA6hlUgAJGFQxWcSUFCLiKSS0Kq8IXcAAMmiVQc6Uy6gAFJKODrzkUDUaIA4HLAMVicVkgqY0MoOJptHoADSeog+v06XRB9GYyDYoRlUSiQzGhQ+ACUZSTED8rKqqMwLoayg0GF+MZxqlo-KCuXYMrpUbdQm1wUgar1mpb1pbbbthtkztdZab2XgXtDWnDQaYY99E8DaMHsfjieZ-irovFqUldfliuhsK7NdburtUgA8lgMoe8s2jz2xEGAOSmxCP8R9ykvkdHncNoe3vJ7xKcpVxzCAAQBVkhQ8KJpGzYBTCbSBwB5I91A3NAJRbHcFUhfdUnyPgNRkHxwGIZBiCEaAHlQvIADoX0zJ0AD0RlZRDNHAU0olo9gGIyRBigABhA5NwFY1leMgfjMjolAiGaQZUnNbiJHEfsFDEp0WLYtNDCAA) to demonstrate the issue.

**Current state:**

<img width="878" alt="Screenshot 2023-10-08 at 11 37 04 PM" src="https://github.com/oramasearch/orama/assets/4009209/c783b8e0-ac9e-4dce-a9da-c9b40ea23a46">


**Proposed solution in this PR:**

<img width="675" alt="Screenshot 2023-10-08 at 11 36 24 PM" src="https://github.com/oramasearch/orama/assets/4009209/0dc251cd-5024-4169-a19c-461a06349ddb">
