### PR TITLE
fix: create custom tokenizer

### DIFF
--- a/packages/orama/src/methods/create.ts
+++ b/packages/orama/src/methods/create.ts
@@ -105,7 +105,7 @@ export async function create<
     id = await uniqueId()
   }
 
-  let tokenizer = components.tokenizer as Tokenizer
+  let tokenizer = components.tokenizer
   let index: TIndex | undefined = components.index
   let documentsStore: TDocumentStore | undefined = components.documentsStore
   let sorter: TSorter | undefined = components.sorter
@@ -113,9 +113,12 @@ export async function create<
   if (!tokenizer) {
     // Use the default tokenizer
     tokenizer = await createTokenizer({ language: language ?? 'english' })
-  } else if (!tokenizer.tokenize) {
+  } else if (!(tokenizer as Tokenizer).tokenize) {
     // If there is no tokenizer function, we assume this is a TokenizerConfig
     tokenizer = await createTokenizer(tokenizer)
+  } else {
+    const customTokenizer = tokenizer as Tokenizer
+    tokenizer = customTokenizer
   }
 
   if (components.tokenizer && language) {


### PR DESCRIPTION
Fixes #492.

Correctly create the tokenizer using the custom one passed via parameters.

Speaking about the linked issue, the provided example seems to be wrong:

```ts
const orama = await create({
    schema: {
      foo: "string",
    },
    components: {
      tokenizer: {
        normalizationCache: new Map([["english:foo:Bar", "bar"]]),
        stemming: true,
      },
    },
  });
```

According to the documentation, a custom tokenizer is made up of at least `language`, `normalizationCache`, and the `tokenize` function (see [Tokenizer](https://github.com/oramasearch/orama/blob/main/packages/orama/src/types.ts#L730) interface). For the time being, passing a custom `normalizationCache` is only possible if a custom tokenizer is used.

Passing a custom normalisation cache with default values without using a custom `tokenize` function could be harmful (or at the very least ineffective), because it would be supplied with specific keys determined by the language inside the native tokenizer.