### PR TITLE
add `usePrefixWithTolerance`  param

### DIFF
--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -491,8 +491,8 @@ export async function search<T extends AnyOrama, ResultDocument = TypedDocument<
     throw createError('WRONG_SEARCH_PROPERTY_TYPE', prop)
   }
 
-  const { exact, tolerance } = context.params
-  const searchResult = radixFind(node, { term, exact, tolerance })
+  const { exact, tolerance, usePrefixWithTolerance } = context.params
+  const searchResult = radixFind(node, { term, exact, tolerance, usePrefixWithTolerance })
   const ids = new Set<InternalDocumentID>()
 
   for (const key in searchResult) {

--- a/packages/orama/src/trees/radix.ts
+++ b/packages/orama/src/trees/radix.ts
@@ -260,20 +260,20 @@ function _findLevenshtein (
   }
 }
 
-function mergeFindResult(r1: FindResult, r2: FindResult) {
-  const output: FindResult = {}
+function mergeFindResult (...results: FindResult[]): FindResult {
+  const mergedResult: FindResult = {};
 
-  for (const key in r1) {
-    output[key] = r1[key];
+  for (const result of results) {
+    Object.keys(result).forEach(key => {
+      if (!mergedResult[key]) {
+        mergedResult[key] = [];
+      }
+
+      mergedResult[key] = Array.from(new Set(Array.from(mergedResult[key]).concat(result[key])));
+    })
   }
 
-  for (const key in r2) {
-    output[key] = output[key]
-      ? Array.from(new Set(output[key].concat(r2[key])))
-      : r2[key];
-  }
-  
-  return output;
+  return mergedResult;
 }
 
 export function find (root: Node, { term, exact, tolerance, usePrefixWithTolerance }: FindParams): FindResult {
@@ -299,7 +299,7 @@ export function find (root: Node, { term, exact, tolerance, usePrefixWithToleran
   return findByDefault(root, { term, exact, tolerance });
 }
 
-export function findByDefault(root: Node, { term, exact, tolerance }: FindParams): FindResult {
+export function findByDefault (root: Node, { term, exact, tolerance }: FindParams): FindResult {
   const termLength = term.length
   for (let i = 0; i < termLength; i++) {
     const character = term[i]

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -297,6 +297,11 @@ export type SearchParams<T extends AnyOrama, ResultDocument = TypedDocument<T>> 
    * between the term and the searchable property.
    */
   tolerance?: number
+   /**
+   * Allowing to execute the default prefix search even when tolerance is not 0
+   * The default value is false
+   */
+  usePrefixWithTolerance?: boolean
   /**
    * The BM25 parameters to use.
    *


### PR DESCRIPTION
# This PR does the following: 
1. Adds the `usePrefixWithTolerance` option to allow executing the default prefix search when tolerance is not 0. 
2. Splits the `find` method in the `radix.ts` into default search and adds a method to merge the results.

close #544
/claim #544

# Request
please let me know first if this solution is feasible before I proceed with adding tests and other tasks.