### PR TITLE
chore: use biome to format code

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
+	"formatter": {
+		"lineWidth": 120
+	},
+	"files": {
+		"include": ["packages/plugin-vitepress"],
+		"maxSize": 1000000000
+	},
+	"javascript": {
+		"formatter": {
+			"semicolons": "asNeeded",
+			"trailingComma": "all",
+			"arrowParentheses": "asNeeded",
+			"bracketSpacing": true,
+			"quoteStyle": "single"
+		}
+	},
+	"organizeImports": {
+		"enabled": false
+	},
+	"linter": {
+		"enabled": false
+	}
+}

--- a/biome.json
+++ b/biome.json
@@ -1,22 +1,21 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
-	"formatter": {
-		"lineWidth": 120
-	},
-	"files": {
-		"include": ["packages/plugin-vitepress"],
-		"maxSize": 1000000000
-	},
-	"javascript": {
-		"formatter": {
-			"semicolons": "asNeeded",
-			"trailingComma": "all",
-			"arrowParentheses": "asNeeded",
-			"bracketSpacing": true,
-			"quoteStyle": "single"
-		}
-	},
-	"linter": {
-		"enabled": false
-	}
+  "$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
+  "formatter": {
+    "lineWidth": 120,
+    "indentStyle": "space"
+  },
+  "files": {
+    "include": ["plugin-vitepress"],
+    "maxSize": 1000000000
+  },
+  "javascript": {
+    "formatter": {
+      "semicolons": "asNeeded",
+      "trailingComma": "none",
+      "quoteStyle":"single"
+    }
+  },
+  "linter": {
+    "enabled": false
+  }
 }

--- a/biome.json
+++ b/biome.json
@@ -16,9 +16,6 @@
 			"quoteStyle": "single"
 		}
 	},
-	"organizeImports": {
-		"enabled": false
-	},
 	"linter": {
 		"enabled": false
 	}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:plugin-match-highlight": "cd packages/plugin-match-highlight && npm run build",
     "build:plugin-parsedoc": "cd packages/plugin-parsedoc && npm run build",
     "format": "prettier -w packages",
+    "format:biome": "biome format --write ./packages",
     "lint": "turbo lint",
     "test": "turbo test",
     "test:orama": "cd packages/orama && npm test",
@@ -29,6 +30,7 @@
     "publish-packages": "node scripts/release.mjs"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.4.1",
     "@swc/cli": "^0.1.59",
     "@swc/core": "^1.3.27",
     "@types/node": "^18.11.18",

--- a/packages/plugin-vitepress/src/index.ts
+++ b/packages/plugin-vitepress/src/index.ts
@@ -9,157 +9,157 @@ import slugify from 'slugify'
 import { readFileSync } from 'fs'
 
 type OramaSchema = {
-	title: string
-	content: string
-	path: string
-	category: string
-	section: string
+  title: string
+  content: string
+  path: string
+  category: string
+  section: string
 }
 
 type ParserResult = {
-	title: string
-	header: string
-	content: string
-	path: string
+  title: string
+  header: string
+  content: string
+  path: string
 }
 
 const md = new MarkdownIt({
-	html: true,
+  html: true
 })
 
 async function createOramaContentLoader(paths: string[], root: string) {
-	const contents = paths
-		.map(file => ({
-			path: file.replace(root, '').replace('.md', ''),
-			html: md.render(readFileSync(file, 'utf-8'), ''),
-		}))
-		.map(parseHTMLContent)
-		.map(formatForOrama)
-		.flat()
+  const contents = paths
+    .map((file) => ({
+      path: file.replace(root, '').replace('.md', ''),
+      html: md.render(readFileSync(file, 'utf-8'), '')
+    }))
+    .map(parseHTMLContent)
+    .map(formatForOrama)
+    .flat()
 
-	const db = await create({
-		schema: presets.docusaurus.schema,
-	})
+  const db = await create({
+    schema: presets.docusaurus.schema
+  })
 
-	// @ts-ignore
-	await insertMultiple(db, contents)
+  // @ts-ignore
+  await insertMultiple(db, contents)
 
-	return persist(db, 'json', 'browser')
+  return persist(db, 'json', 'browser')
 }
 
 function parseHTMLContent({ html, path }: { html: string; path: string }): Array<ParserResult> {
-	const dom = new JSDOM(html)
-	const document = dom.window.document
+  const dom = new JSDOM(html)
+  const document = dom.window.document
 
-	const sections: Array<ParserResult> = []
+  const sections: Array<ParserResult> = []
 
-	const headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6')
-	headers.forEach(header => {
-		const sectionTitle = header.textContent!.trim()
-		const headerTag = header.tagName.toLowerCase()
-		let sectionContent = ''
+  const headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6')
+  headers.forEach((header) => {
+    const sectionTitle = header.textContent!.trim()
+    const headerTag = header.tagName.toLowerCase()
+    let sectionContent = ''
 
-		let sibling = header.nextElementSibling
-		while (sibling && !['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(sibling.tagName)) {
-			sectionContent += sibling.textContent!.trim() + '\n'
-			sibling = sibling.nextElementSibling
-		}
+    let sibling = header.nextElementSibling
+    while (sibling && !['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(sibling.tagName)) {
+      sectionContent += sibling.textContent!.trim() + '\n'
+      sibling = sibling.nextElementSibling
+    }
 
-		sections.push({
-			title: sectionTitle,
-			header: headerTag,
-			content: sectionContent,
-			path,
-		})
-	})
+    sections.push({
+      title: sectionTitle,
+      header: headerTag,
+      content: sectionContent,
+      path
+    })
+  })
 
-	return sections
+  return sections
 }
 
 function formatForOrama(data: Array<ParserResult>): Array<OramaSchema> {
-	try {
-		const firstH1Header = data.find(section => section.header === 'h1')
+  try {
+    const firstH1Header = data.find((section) => section.header === 'h1')
 
-		return data.map(res => ({
-			title: res.title,
-			content: res.content,
-			section: firstH1Header!.title.replace(/\s$/, ''),
-			path: res?.path + '#' + slugify.default(res.title, { lower: true }),
-			category: '',
-		}))
-	} catch (error) {
-		console.error(error)
-		return []
-	}
+    return data.map((res) => ({
+      title: res.title,
+      content: res.content,
+      section: firstH1Header!.title.replace(/\s$/, ''),
+      path: res?.path + '#' + slugify.default(res.title, { lower: true }),
+      category: ''
+    }))
+  } catch (error) {
+    console.error(error)
+    return []
+  }
 }
 
 export function OramaPlugin(): Plugin {
-	let resolveConfig: any
-	const virtualModuleId = 'virtual:search-data'
-	const resolvedVirtualModuleId = `\0${virtualModuleId}`
+  let resolveConfig: any
+  const virtualModuleId = 'virtual:search-data'
+  const resolvedVirtualModuleId = `\0${virtualModuleId}`
 
-	return {
-		name: 'oramasearch',
-		enforce: 'pre',
+  return {
+    name: 'oramasearch',
+    enforce: 'pre',
 
-		configResolved(config: any) {
-			if (resolveConfig) {
-				return
-			}
-			resolveConfig = config
+    configResolved(config: any) {
+      if (resolveConfig) {
+        return
+      }
+      resolveConfig = config
 
-			const vitepressConfig: SiteConfig = config.vitepress
-			if (!vitepressConfig) {
-				return
-			}
+      const vitepressConfig: SiteConfig = config.vitepress
+      if (!vitepressConfig) {
+        return
+      }
 
-			const selfBuildEnd = vitepressConfig.buildEnd
+      const selfBuildEnd = vitepressConfig.buildEnd
 
-			vitepressConfig.buildEnd = (siteConfig: any) => {
-				selfBuildEnd?.(siteConfig)
-				siteConfig = Object.assign(siteConfig || {})
-				pluginSiteConfig?.buildEnd?.(siteConfig)
-			}
+      vitepressConfig.buildEnd = (siteConfig: any) => {
+        selfBuildEnd?.(siteConfig)
+        siteConfig = Object.assign(siteConfig || {})
+        pluginSiteConfig?.buildEnd?.(siteConfig)
+      }
 
-			const selfTransformHead = vitepressConfig.transformHead
+      const selfTransformHead = vitepressConfig.transformHead
 
-			vitepressConfig.transformHead = async ctx => {
-				const selfHead = (await Promise.resolve(selfTransformHead?.(ctx))) || []
-				const pluginHead = (await Promise.resolve(pluginSiteConfig?.transformHead?.(ctx))) || []
-				return selfHead.concat(pluginHead)
-			}
-		},
-		config: () => ({
-			resolve: {
-				alias: {
-					'./VPNavBarSearch.vue': new URL('./Search.vue', import.meta.url).pathname,
-				},
-			},
-		}),
+      vitepressConfig.transformHead = async (ctx) => {
+        const selfHead = (await Promise.resolve(selfTransformHead?.(ctx))) || []
+        const pluginHead = (await Promise.resolve(pluginSiteConfig?.transformHead?.(ctx))) || []
+        return selfHead.concat(pluginHead)
+      }
+    },
+    config: () => ({
+      resolve: {
+        alias: {
+          './VPNavBarSearch.vue': new URL('./Search.vue', import.meta.url).pathname
+        }
+      }
+    }),
 
-		async resolveId(id) {
-			if (id === virtualModuleId) {
-				return resolvedVirtualModuleId
-			}
-		},
+    async resolveId(id) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId
+      }
+    },
 
-		async load(this, id) {
-			if (id !== resolvedVirtualModuleId) return
+    async load(this, id) {
+      if (id !== resolvedVirtualModuleId) return
 
-			const root = resolveConfig.vitepress.root
-			const pages = resolveConfig.vitepress.pages.map((page: string) => `${root}/${page}`)
+      const root = resolveConfig.vitepress.root
+      const pages = resolveConfig.vitepress.pages.map((page: string) => `${root}/${page}`)
 
-			return `
+      return `
         const data = ${JSON.stringify(await createOramaContentLoader(pages, root))};
         export default data;
       `
-		},
-	}
+    }
+  }
 }
 
 const pluginSiteConfig: Partial<SiteConfig> = {
-	buildEnd(ctx) {},
-	transformHead(ctx) {
-		return []
-	},
+  buildEnd(ctx) {},
+  transformHead(ctx) {
+    return []
+  }
 }

--- a/packages/plugin-vitepress/src/index.ts
+++ b/packages/plugin-vitepress/src/index.ts
@@ -9,157 +9,157 @@ import slugify from 'slugify'
 import { readFileSync } from 'fs'
 
 type OramaSchema = {
-  title: string
-  content: string
-  path: string
-  category: string
-  section: string
+	title: string
+	content: string
+	path: string
+	category: string
+	section: string
 }
 
 type ParserResult = {
-  title: string
-  header: string
-  content: string
-  path: string
+	title: string
+	header: string
+	content: string
+	path: string
 }
 
 const md = new MarkdownIt({
-  html: true
+	html: true,
 })
 
-async function createOramaContentLoader (paths: string[], root: string) {
-  const contents = paths
-    .map(file => ({
-      path: file.replace(root, '').replace('.md', ''),
-      html: md.render(readFileSync(file, 'utf-8'), '')
-    }))
-    .map(parseHTMLContent)
-    .map(formatForOrama)
-    .flat()
+async function createOramaContentLoader(paths: string[], root: string) {
+	const contents = paths
+		.map(file => ({
+			path: file.replace(root, '').replace('.md', ''),
+			html: md.render(readFileSync(file, 'utf-8'), ''),
+		}))
+		.map(parseHTMLContent)
+		.map(formatForOrama)
+		.flat()
 
-  const db = await create({
-    schema: presets.docusaurus.schema
-  })
+	const db = await create({
+		schema: presets.docusaurus.schema,
+	})
 
-  // @ts-ignore
-  await insertMultiple(db, contents)
+	// @ts-ignore
+	await insertMultiple(db, contents)
 
-  return persist(db, 'json', 'browser')
+	return persist(db, 'json', 'browser')
 }
 
-function parseHTMLContent({ html, path }: { html: string, path: string }): Array<ParserResult> {
-  const dom = new JSDOM(html);
-  const document = dom.window.document;
+function parseHTMLContent({ html, path }: { html: string; path: string }): Array<ParserResult> {
+	const dom = new JSDOM(html)
+	const document = dom.window.document
 
-  const sections: Array<ParserResult> = [];
+	const sections: Array<ParserResult> = []
 
-  const headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
-  headers.forEach(header => {
-    const sectionTitle = header.textContent!.trim();
-    const headerTag = header.tagName.toLowerCase();
-    let sectionContent = '';
+	const headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6')
+	headers.forEach(header => {
+		const sectionTitle = header.textContent!.trim()
+		const headerTag = header.tagName.toLowerCase()
+		let sectionContent = ''
 
-    let sibling = header.nextElementSibling;
-    while (sibling && !['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(sibling.tagName)) {
-      sectionContent += sibling.textContent!.trim() + '\n';
-      sibling = sibling.nextElementSibling;
-    }
+		let sibling = header.nextElementSibling
+		while (sibling && !['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(sibling.tagName)) {
+			sectionContent += sibling.textContent!.trim() + '\n'
+			sibling = sibling.nextElementSibling
+		}
 
-    sections.push({
-      title: sectionTitle,
-      header: headerTag,
-      content: sectionContent,
-      path
-    });
-  });
+		sections.push({
+			title: sectionTitle,
+			header: headerTag,
+			content: sectionContent,
+			path,
+		})
+	})
 
-  return sections;
+	return sections
 }
 
 function formatForOrama(data: Array<ParserResult>): Array<OramaSchema> {
-  try {
-    const firstH1Header = data.find(section => section.header === 'h1')
+	try {
+		const firstH1Header = data.find(section => section.header === 'h1')
 
-    return data.map((res) => ({
-      title: res.title,
-      content: res.content,
-      section: firstH1Header!.title.replace(/\s$/, ''),
-      path: res?.path + '#' + slugify.default(res.title, { lower: true }),
-      category: ''
-    }))
-  } catch (error) {
-    console.error(error)
-    return []
-  }
+		return data.map(res => ({
+			title: res.title,
+			content: res.content,
+			section: firstH1Header!.title.replace(/\s$/, ''),
+			path: res?.path + '#' + slugify.default(res.title, { lower: true }),
+			category: '',
+		}))
+	} catch (error) {
+		console.error(error)
+		return []
+	}
 }
 
 export function OramaPlugin(): Plugin {
-  let resolveConfig: any
-  const virtualModuleId = "virtual:search-data";
-  const resolvedVirtualModuleId = `\0${virtualModuleId}`
+	let resolveConfig: any
+	const virtualModuleId = 'virtual:search-data'
+	const resolvedVirtualModuleId = `\0${virtualModuleId}`
 
-  return {
-    name: 'oramasearch',
-    enforce: 'pre',
+	return {
+		name: 'oramasearch',
+		enforce: 'pre',
 
-    configResolved(config: any) {
-      if (resolveConfig) {
-        return
-      }
-      resolveConfig = config
+		configResolved(config: any) {
+			if (resolveConfig) {
+				return
+			}
+			resolveConfig = config
 
-      const vitepressConfig: SiteConfig = config.vitepress
-      if (!vitepressConfig) {
-        return
-      }
+			const vitepressConfig: SiteConfig = config.vitepress
+			if (!vitepressConfig) {
+				return
+			}
 
-      const selfBuildEnd = vitepressConfig.buildEnd
+			const selfBuildEnd = vitepressConfig.buildEnd
 
-      vitepressConfig.buildEnd = (siteConfig: any) => {
-        selfBuildEnd?.(siteConfig)
-        siteConfig = Object.assign(siteConfig || {})
-        pluginSiteConfig?.buildEnd?.(siteConfig)
-      }
+			vitepressConfig.buildEnd = (siteConfig: any) => {
+				selfBuildEnd?.(siteConfig)
+				siteConfig = Object.assign(siteConfig || {})
+				pluginSiteConfig?.buildEnd?.(siteConfig)
+			}
 
-      const selfTransformHead = vitepressConfig.transformHead
+			const selfTransformHead = vitepressConfig.transformHead
 
-      vitepressConfig.transformHead = async (ctx) => {
-        const selfHead = (await Promise.resolve(selfTransformHead?.(ctx))) || []
-        const pluginHead = (await Promise.resolve(pluginSiteConfig?.transformHead?.(ctx))) || []
-        return selfHead.concat(pluginHead)
-      }
-    },
-    config: () => ({
-      resolve: {
-        alias: {
-          './VPNavBarSearch.vue': new URL('./Search.vue', import.meta.url).pathname,
-        },
-      }
-    }),
+			vitepressConfig.transformHead = async ctx => {
+				const selfHead = (await Promise.resolve(selfTransformHead?.(ctx))) || []
+				const pluginHead = (await Promise.resolve(pluginSiteConfig?.transformHead?.(ctx))) || []
+				return selfHead.concat(pluginHead)
+			}
+		},
+		config: () => ({
+			resolve: {
+				alias: {
+					'./VPNavBarSearch.vue': new URL('./Search.vue', import.meta.url).pathname,
+				},
+			},
+		}),
 
-    async resolveId(id) {
-      if (id === virtualModuleId) {
-        return resolvedVirtualModuleId;
-      }
-    },
+		async resolveId(id) {
+			if (id === virtualModuleId) {
+				return resolvedVirtualModuleId
+			}
+		},
 
-    async load(this, id) {
-      if (id !== resolvedVirtualModuleId) return;
+		async load(this, id) {
+			if (id !== resolvedVirtualModuleId) return
 
-      const root = resolveConfig.vitepress.root
-      const pages = resolveConfig.vitepress.pages.map((page: string) => `${root}/${page}`)
+			const root = resolveConfig.vitepress.root
+			const pages = resolveConfig.vitepress.pages.map((page: string) => `${root}/${page}`)
 
-      return `
+			return `
         const data = ${JSON.stringify(await createOramaContentLoader(pages, root))};
         export default data;
       `
-    }
-  }
+		},
+	}
 }
 
 const pluginSiteConfig: Partial<SiteConfig> = {
-  buildEnd(ctx) {},
-  transformHead(ctx) {
-    return []
-  }
+	buildEnd(ctx) {},
+	transformHead(ctx) {
+		return []
+	},
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^2.26.0
         version: 2.26.0
     devDependencies:
+      '@biomejs/biome':
+        specifier: 1.4.1
+        version: 1.4.1
       '@swc/cli':
         specifier: ^0.1.59
         version: 0.1.59(@swc/core@1.3.27)
@@ -3833,6 +3836,74 @@ packages:
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
+
+  /@biomejs/biome@1.4.1:
+    resolution: {integrity: sha512-JccVAwPbhi37pdxbAGmaOBjUTKEwEjWAhl7rKkVVuXHo4MLASXJ5HR8BTgrImi4/7rTBsGz1tgVD1Kwv1CHGRg==}
+    engines: {node: '>=14.*'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.4.1
+      '@biomejs/cli-darwin-x64': 1.4.1
+      '@biomejs/cli-linux-arm64': 1.4.1
+      '@biomejs/cli-linux-x64': 1.4.1
+      '@biomejs/cli-win32-arm64': 1.4.1
+      '@biomejs/cli-win32-x64': 1.4.1
+    dev: true
+
+  /@biomejs/cli-darwin-arm64@1.4.1:
+    resolution: {integrity: sha512-PZWy2Idndqux38p6AXSDQM2ldRAWi32bvb7bMbTN0ALzpWYMYnxd71ornatumSSJYoNhKmxzDLq+jct7nZJ79w==}
+    engines: {node: '>=14.*'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@biomejs/cli-darwin-x64@1.4.1:
+    resolution: {integrity: sha512-soj3BWhnsM1M2JlzR09cibUzG1owJqetwj/Oo7yg0foijo9lNH9XWXZfJBYDKgW/6Fomn+CC2EcUS+hisQzt9g==}
+    engines: {node: '>=14.*'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@biomejs/cli-linux-arm64@1.4.1:
+    resolution: {integrity: sha512-YIZqfJUg4F+fPsBTXxgD7EU2E5OAYbmYSl/snf4PevwfQCWE/omOFZv+NnIQmjYj9I7ParDgcJvanoA3/kO0JQ==}
+    engines: {node: '>=14.*'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@biomejs/cli-linux-x64@1.4.1:
+    resolution: {integrity: sha512-9YOZw3qBd/KUj63A6Hn2zZgzGb2nbESM0qNmeMXgmqinVKM//uc4OgY5TuKITuGjMSvcVxxd4dX1IzYjV9qvNQ==}
+    engines: {node: '>=14.*'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@biomejs/cli-win32-arm64@1.4.1:
+    resolution: {integrity: sha512-nWQbvkNKxYn/kCQ0yVF8kCaS3VzaGvtFSmItXiMknU4521LDjJ7tNWH12Gol+pIslrCbd4E1LhJa0a3ThRsBVg==}
+    engines: {node: '>=14.*'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@biomejs/cli-win32-x64@1.4.1:
+    resolution: {integrity: sha512-88fR2CQxQ4YLs2BUDuywWYQpUKgU3A3sTezANFc/4LGKQFFLV2yX+F7QAdZVkMHfA+RD9Xg178HomM/6mnTNPA==}
+    engines: {node: '>=14.*'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}


### PR DESCRIPTION
Hi peeps, how are you? 👋 

I am proposing an alternative to Prettier, Biome. https://biomejs.dev/formatter/

My idea is to slowly adopt the tool, and slowly adopt also linter (alongside eslint for the time being) and import sorting.

The PR only applies changes to `plugin-vitepress` as a starting point. I am happy to guide the migration to the rest of the code base.

While I was replacing it, I realized that prettier isn't used in the code base, so I changed the biome options to meet `ts-standard` - the library that Michele uses. However, there are still some differences due to some inconsistencies in the code.

Let me know what you guys think. If the change is welcomed, we could use this PR to decide the formatting style of the code base.

Thank you :) 