### PR TITLE
perf: avoid new array while insertNode

### DIFF
--- a/packages/orama/src/trees/avl.ts
+++ b/packages/orama/src/trees/avl.ts
@@ -211,7 +211,9 @@ export function insert<K, V> (rootNode: RootNode<K, V[]>, key: K, newValue: V[])
     } else if (key > node.k) {
       node.r = insertNode(node.r, key, newValue)
     } else {
-      node.v = Array.from(new Set([...node.v, ...newValue]))
+      for (const value of newValue) {
+        node.v.push(value);
+      }
       return node
     }
 


### PR DESCRIPTION
I don't think there's any valid reason to create a new array every time.

The old behavior also didn't care about the item being already added, should we care about that too?

Benchmark:

```js
import { faker } from "@faker-js/faker";
import { create, insertMultiple, search } from "./dist/index.js";

// function to print the used memory
function printUsedMemory() {
  const used = process.memoryUsage().heapUsed / 1024 / 1024;
  console.log(`The script uses approximately ${Math.round(used * 100) / 100} MB`);
}

// create fake data
const data = Array.from({length: 100000}, () => ({
  id: faker.string.uuid(),
  name: faker.person.firstName(),
  surname: faker.person.lastName(),
  fiscalCode: faker.string.alphanumeric({length: 16, casing: "uppercase"}),
  season: faker.number.int({min: 2010, max: 2020}),
}));
printUsedMemory();

// create index and add data
const db = await create({
  schema: {
    id: "string",
    name: "string",
    surname: "string",
    fiscalCode: "string",
    season: "number",
  },
});

await insertMultiple(db, data);
console.log("Index created");

printUsedMemory();

// search the index
const results = await search(db, {
  term: "john",
  properties: "*",
});

console.log(results)
printUsedMemory();
```

Without the change: 20s
With the change: 4s
