### PR TITLE
chore(devcontainer extensions setup): update devcontainer extensions …

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,29 @@
 {
     "name": "orama devcontainer",
-    "extensions": [
-      "esbenp.prettier-vscode",
-      "usernamehw.errorlens",
-      "dbaeumer.vscode-eslint",
-      "yzhang.markdown-all-in-one",
-      "christian-kohler.path-intellisense",
-      "pflannery.vscode-versionlens",
-      "ms-azuretools.vscode-docker"
-    ],
     "build": {
       "dockerfile": "Dockerfile"
     },
     "waitFor": "onCreateCommand",
     "updateContentCommand": "pnpm install",
     "customizations": {
+      "vscode": {
+        "extensions": [
+          "esbenp.prettier-vscode",
+          "usernamehw.errorlens",
+          "dbaeumer.vscode-eslint",
+          "yzhang.markdown-all-in-one",
+          "christian-kohler.path-intellisense",
+          "pflannery.vscode-versionlens",
+          "ms-azuretools.vscode-docker"
+        ]
+      },
       "codespaces": {
         "openFiles": ["CONTRIBUTING.md", "README.md"]
       }
     },
     "mounts": [
       "source=orama-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume", // deps volume
-      "source=orama-pnpm_store,target=${containerWorkspaceFolder}/.pnpm-store,type=volume" // pnpm-store volume
+      "source=orama-pnpm_store,target=${containerWorkspaceFolder}/.pnpm-store,type=volume", // pnpm-store volume
+      "source=orama-vscode-extensions,target=/root/.vscode-server/extensions,type=volume" // vscode extensions volume
     ]
   }


### PR DESCRIPTION
Devcontainer extensions setup updated to the new _devcontainer.json_ schema.
This setup is valid for both VSCode and Github Codespaces, as stated [here](https://containers.dev/supporting#visual-studio-code).
