### PR TITLE
Fix #601 - Skipping of keys in Object.prototype in search function

### DIFF
--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -490,6 +490,11 @@ export async function search<T extends AnyOrama, ResultDocument = TypedDocument<
   const ids = new Set<InternalDocumentID>()
 
   for (const key in searchResult) {
+    //if same key is in the Object.prototype, skip it
+    if(key in Object.prototype && Object.prototype[key] === searchResult[key]) {
+      continue;
+    }
+
     for (const id of searchResult[key]) {
       ids.add(id)
     }


### PR DESCRIPTION
Fixes #601 

I also conducted some speed tests for the search function after this implementation, and the speed results were the same. I made sure that it had no effect on search speed.

I am not entirely sure that this PR won't create some inconsistencies in the codebase. Therefore, a check from the development team would be highly appreciated.