### PR TITLE
Fix #601 - Skipping of keys in Object.prototype in search function

### DIFF
--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -57,7 +57,7 @@ import {
   searchByPolygon
 } from '../trees/bkd.js'
 
-import { convertDistanceToMeters, intersect, safeArrayPush } from '../utils.js'
+import { convertDistanceToMeters, intersect, safeArrayPush, getOwnProperty } from '../utils.js'
 import { BM25 } from './algorithms.js'
 import { getMagnitude } from './cosine-similarity.js'
 import { getInnerType, getVectorSize, isArrayType, isVectorType } from './defaults.js'
@@ -489,14 +489,13 @@ export async function search<T extends AnyOrama, ResultDocument = TypedDocument<
   const searchResult = radixFind(node, { term, exact, tolerance })
   const ids = new Set<InternalDocumentID>()
 
-  for (const key in searchResult) {
-    //if same key is in the Object.prototype, skip it
-    if(key in Object.prototype && Object.prototype[key] === searchResult[key]) {
-      continue;
-    }
+  for(const key in searchResult){
+    //skip keys inherited from prototype
+    const ownProperty = getOwnProperty(searchResult, key);
+    if(!ownProperty) continue;
 
-    for (const id of searchResult[key]) {
-      ids.add(id)
+    for (const id of searchResult[key]){
+        ids.add(id);
     }
   }
 

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -490,6 +490,11 @@ export async function search<T extends AnyOrama, ResultDocument = TypedDocument<
   const ids = new Set<InternalDocumentID>()
 
   for (const key in searchResult) {
+    //if same key is in the Object.prototype, skip it
+    if(key in Object.prototype && Object.prototype[key] === searchResult[key]) {
+      continue;
+    }
+
     for (const id of searchResult[key]) {
       ids.add(id)
     }

--- a/packages/orama/tests/search.test.ts
+++ b/packages/orama/tests/search.test.ts
@@ -794,6 +794,22 @@ t.test('fix-544', async t => {
   t.end()
 })
 
+t.test('fix-601', async t => {
+  const db = await create({
+    schema: {
+      name: 'string'
+    } as const
+  })
+
+  Object.prototype['examplePrototypeFunction'] = () => {};
+
+  await insert(db, { name: 'John Doe' });
+  const result = await search(db, { term: 'John Doe' });
+
+  t.equal(result.count, 1);
+  t.end()
+})
+
 async function createSimpleDB() {
   let i = 0
   const db = await create({


### PR DESCRIPTION
Fixes #601 

I also conducted some speed tests for the search function after this implementation, and the speed results were the same. I made sure that it had no effect on search speed.

I am not entirely sure that this PR won't create some inconsistencies in the codebase. Therefore, a check from the development team would be highly appreciated.

Also, closed #602 due to committing on wrong branch. 