### PR TITLE
Fix wrong order of params

### DIFF
--- a/packages/orama/src/methods/search-fulltext.ts
+++ b/packages/orama/src/methods/search-fulltext.ts
@@ -29,7 +29,7 @@ export async function fullTextSearch<T extends AnyOrama, ResultDocument = TypedD
     await runBeforeSearch(orama.beforeSearch, orama, params, language)
   }
 
-  params.relevance = Object.assign(params.relevance ?? {}, defaultBM25Params)
+  params.relevance = Object.assign(defaultBM25Params, params.relevance ?? {})
 
   const vectorProperties = Object.keys(orama.data.index.vectorIndexes)
 

--- a/packages/orama/src/methods/search-hybrid.ts
+++ b/packages/orama/src/methods/search-hybrid.ts
@@ -132,7 +132,7 @@ async function getFullTextSearchIDs<T extends AnyOrama, ResultDocument = TypedDo
   language?: string
 ): Promise<TokenScore[]> {
   const timeStart = await getNanosecondsTime()
-  params.relevance = Object.assign(params.relevance ?? {}, defaultBM25Params)
+  params.relevance = Object.assign(defaultBM25Params, params.relevance ?? {})
 
   const { term, properties, threshold = 1 } = params
 


### PR DESCRIPTION
This PR fixes issue #641 where relevancy params where in wrong order in `Object.assign`