### PR TITLE
chore: add plugins link

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ Read the complete documentation at [https://docs.askorama.ai](https://docs.askor
 
 # Official Orama Plugins
 
+[Family of Orama Plugins](https://npm-compare.com/@orama/plugin-analytics,@orama/plugin-astro,@orama/plugin-data-persistence,@orama/plugin-docusaurus,@orama/plugin-docusaurus-v3,@orama/plugin-nextra,@orama/plugin-vitepress):
+
 - [Plugin Vitepress](https://docs.askorama.ai/open-source/plugins/plugin-vitepress)
 - [Plugin Docusaurus](https://docs.askorama.ai/open-source/plugins/plugin-docusaurus)
 - [Plugin Analytics](https://docs.askorama.ai/open-source/plugins/plugin-analytics)


### PR DESCRIPTION
This pull request adds a link that highlights the available plugins in the Orama ecosystem.

As one of the maintainers of npm-compare.com, I strive to provide users with insights into the download trends of various packages, making it easier for them to choose the right tools for their projects. This link will aid users in discovering the different plugins available within the Orama ecosystem while also showcasing their popularity and usage over time.

If there are any additional features or improvements you would like to see on npm-compare.com, I’d be happy to help!

Thank you for considering this enhancement to the documentation!