### PR TITLE
fix: disabled chat on local due secure proxy feat missing

### DIFF
--- a/packages/plugin-docusaurus/src/theme/SearchBar/useOrama.ts
+++ b/packages/plugin-docusaurus/src/theme/SearchBar/useOrama.ts
@@ -86,6 +86,7 @@ export const useOrama = () => {
         basic: {
           clientInstance: oramaInstance,
           facetProperty: 'category',
+          disableChat: !endpoint?.url
         },
         custom: searchBoxCustomConfig
       })


### PR DESCRIPTION
- Disable chat on OSS, due to secure proxy feature missing (will be added later)