### PR TITLE
Fix wrong URL to JS SDK

### DIFF
--- a/packages/docs/src/content/docs/cloud/integrating-orama-cloud/official-sdk.mdx
+++ b/packages/docs/src/content/docs/cloud/integrating-orama-cloud/official-sdk.mdx
@@ -16,7 +16,7 @@ Some features may not be available in all SDKs yet.
 
 | Package                                                              | Search Engine       | Answer Engine      | Index Manager       |
 |----------------------------------------------------------------------|---------------------|--------------------|---------------------|
-| [Client JavaScript](https://github.com/oramasearch/oramacloud-client)   | <center>✅</center> | <center>✅</center> | <center>✅</center> |
+| [Client JavaScript](https://github.com/oramasearch/oramacloud-client-javascript)   | <center>✅</center> | <center>✅</center> | <center>✅</center> |
 | [Client PHP](https://github.com/oramasearch/oramacloud-client-php)      | <center>✅</center> | <center>🚧</center> | <center>✅</center> |
 | [Client Swift](https://github.com/oramasearch/oramacloud-client-swift)  | <center>✅</center> | <center>🚧</center> | <center>🚧</center> |
 | [Client Kotlin](https://github.com/oramasearch/oramacloud-client-kotlin)| <center>✅</center> | <center>✅</center> | <center>✅</center> |


### PR DESCRIPTION
Fix wrong URL for JavaScript SDK