### PR TITLE
fix: fixes tokenizers directory

### DIFF
--- a/packages/tokenizers/package.json
+++ b/packages/tokenizers/package.json
@@ -31,7 +31,7 @@
     "@orama/orama": "workspace:*"
   },
   "files": [
-    "build"
+    "dist"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request includes a small change to the `packages/tokenizers/package.json` file. The change updates the `files` field to include the `dist` directory instead of the `build` directory.