### PR TITLE
Fix/docusaurus duplicating docs

### DIFF
--- a/packages/plugin-docusaurus-v3/.gitignore
+++ b/packages/plugin-docusaurus-v3/.gitignore
@@ -1,0 +1,1 @@
+local-verdaccio-release.sh

--- a/packages/plugin-docusaurus-v3/.npmignore
+++ b/packages/plugin-docusaurus-v3/.npmignore
@@ -1,0 +1,1 @@
+local-verdaccio-instance.sh

--- a/packages/plugin-docusaurus-v3/package.json
+++ b/packages/plugin-docusaurus-v3/package.json
@@ -29,7 +29,7 @@
     "@orama/plugin-analytics": "workspace:*",
     "@orama/plugin-parsedoc": "workspace:*",
     "@orama/react-components": "^0.5.0",
-    "@oramacloud/client": "^1.3.16",
+    "@oramacloud/client": "^2.1.4",
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "jsdom": "^23.2.0",

--- a/packages/plugin-docusaurus-v3/src/index.ts
+++ b/packages/plugin-docusaurus-v3/src/index.ts
@@ -6,7 +6,7 @@ import { cp } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { gzip } from 'pako'
 import { AnyOrama, create, insertMultiple, save } from '@orama/orama'
-import * as OramaCloudClient from '@oramacloud/client'
+import { CloudManager } from '@oramacloud/client'
 import { JSDOM } from 'jsdom'
 import MarkdownIt from 'markdown-it'
 import matter from 'gray-matter'
@@ -124,7 +124,7 @@ async function syncOramaIndex({
   
   const baseUrl = process.env.ORAMA_CLOUD_BASE_URL || 'https://cloud.oramasearch.com/api/v1'
   
-  const cloudManager = new OramaCloudClient.CloudManager({
+  const cloudManager = new CloudManager({
     api_key: apiKey!,
     baseURL: baseUrl
   })
@@ -168,12 +168,14 @@ async function createOramaGzip({
   oramaInstance: AnyOrama
   context: LoadContext
 }) {
-
+  console.debug('Orama: Creating gzipped index file.')
+  
   const version = 'current'
   const serializedOrama = JSON.stringify(save(oramaInstance))
   const gzippedOrama = gzip(serializedOrama)
   writeFileSync(indexPath(context.generatedFilesDir, version), gzippedOrama)
 
+  console.debug('Orama: Gzipped index file created.')
 }
 
 async function fetchOramaDocs(

--- a/packages/plugin-docusaurus-v3/src/index.ts
+++ b/packages/plugin-docusaurus-v3/src/index.ts
@@ -148,7 +148,7 @@ export async function insertChunkDocumentsIntoIndex(oramaIndex: any, docs: any[]
   if (chunk.length > 0) {
     await loggedOperation(
       `Orama: Start documents insertion (range ${offset + 1}-${offset + chunk.length})`,
-      async () => await oramaIndex.insert(docs),
+      async () => await oramaIndex.insert(chunk),
       'Orama: insert created successfully'
     )
     await insertChunkDocumentsIntoIndex(oramaIndex, docs, limit, offset + limit)

--- a/packages/plugin-docusaurus-v3/src/index.ts
+++ b/packages/plugin-docusaurus-v3/src/index.ts
@@ -129,7 +129,7 @@ async function syncOramaIndex({
 
   if (deploy) {
     // Reset index
-    await loggedOperation('Orama: Reset index data', async () => await index.snapshot([]), 'Orama: Index data reset')
+    await loggedOperation('Orama: Reset index data', async () => await index.empty(), 'Orama: Index data reset')
 
     // Populate index
     await insertChunkDocumentsIntoIndex(index, oramaDocs)
@@ -181,7 +181,7 @@ async function fetchOramaDocs(
   context: LoadContext
 ) {
   let versions: string[] = []
-  let docsInstances: string[] = []
+  const docsInstances: string[] = []
   const allOramaDocsPromises: Promise<any>[] = []
 
   searchDataConfig.forEach((config) => {

--- a/packages/plugin-docusaurus-v3/src/theme/SearchBar/index.tsx
+++ b/packages/plugin-docusaurus-v3/src/theme/SearchBar/index.tsx
@@ -14,7 +14,7 @@ export function OramaSearchNoDocs() {
   return (
     <div>
       {searchBoxConfig.basic && (
-        <>
+        <React.Fragment>
           <OramaSearchButton colorScheme={colorMode} className="DocSearch-Button" {...searchBtnConfig}>
             {searchBtnConfig?.text || 'Search'}
           </OramaSearchButton>
@@ -28,7 +28,7 @@ export function OramaSearchNoDocs() {
               }
             }}
           />
-        </>
+        </React.Fragment>
       )}
     </div>
   )
@@ -55,12 +55,14 @@ export function OramaSearchWithDocs({ pluginId }: { pluginId: string }) {
         {searchBtnConfig?.text || 'Search'}
       </OramaSearchButton>
       {searchBoxConfig.basic && (
-        <OramaSearchBox
-          {...searchBoxConfig.basic}
-          {...searchBoxConfig.custom}
-          colorScheme={colorMode}
-          searchParams={searchParams}
-        />
+        <React.Fragment>
+          <OramaSearchBox
+            {...searchBoxConfig.basic}
+            {...searchBoxConfig.custom}
+            colorScheme={colorMode}
+            searchParams={searchParams}
+          />
+        </React.Fragment>
       )}
     </div>
   )

--- a/packages/plugin-docusaurus-v3/src/theme/SearchBar/useOrama.ts
+++ b/packages/plugin-docusaurus-v3/src/theme/SearchBar/useOrama.ts
@@ -4,7 +4,7 @@ import useIsBrowser from '@docusaurus/useIsBrowser'
 import { useColorMode } from '@docusaurus/theme-common'
 import { usePluginData } from '@docusaurus/useGlobalData'
 import { ungzip } from 'pako'
-import { OramaClient } from '@oramacloud/client'
+import * as OramaCloudClient from '@oramacloud/client'
 import { create, insertMultiple } from '@orama/orama'
 import { pluginAnalytics } from '@orama/plugin-analytics'
 
@@ -79,18 +79,26 @@ export default function useOrama() {
   useEffect(() => {
     async function loadOrama() {
       let oramaInstance
-
+      let searchBoxBasicConfig = {}
+      
       if (isCloudData(oramaData)) {
-        oramaInstance = new OramaClient(oramaData.indexConfig)
+        searchBoxBasicConfig = {
+          index: {
+            endpoint: oramaData.indexConfig.endpoint,
+            api_key: oramaData.indexConfig.api_key
+          }
+        }
       } else if (oramaData.oramaDocs) {
         oramaInstance = await createOramaInstance(oramaData.oramaDocs)
+        searchBoxBasicConfig = { clientInstance: oramaInstance }
       } else {
         oramaInstance = await getOramaLocalData(indexGzipURL, oramaData.plugins)
+        searchBoxBasicConfig = { clientInstance: oramaInstance }
       }
-
+      
       setSearchBoxConfig({
         basic: {
-          clientInstance: oramaInstance,
+          ...searchBoxBasicConfig,
           facetProperty: 'category',
           disableChat: !isCloudData(oramaData)
         },

--- a/packages/plugin-docusaurus-v3/src/theme/SearchBar/useOrama.ts
+++ b/packages/plugin-docusaurus-v3/src/theme/SearchBar/useOrama.ts
@@ -4,7 +4,7 @@ import useIsBrowser from '@docusaurus/useIsBrowser'
 import { useColorMode } from '@docusaurus/theme-common'
 import { usePluginData } from '@docusaurus/useGlobalData'
 import { ungzip } from 'pako'
-import * as OramaCloudClient from '@oramacloud/client'
+import { OramaClient } from '@oramacloud/client'
 import { create, insertMultiple } from '@orama/orama'
 import { pluginAnalytics } from '@orama/plugin-analytics'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,8 +458,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0(react-dom@18.3.1)(react@18.3.1)
       '@oramacloud/client':
-        specifier: ^1.3.16
-        version: 1.3.20(typescript@5.7.3)(zod@3.24.1)
+        specifier: ^2.1.4
+        version: 2.1.4
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -7464,8 +7464,8 @@ packages:
     resolution: {integrity: sha512-euTV/2kya290SNkl5m8e/H1na8iDygk74nNtl4E0YZNyYIrEMwE1JwamoroMKGZw2Uz+in/8gH3m1+2YfP0j1w==}
     engines: {node: '>= 16.0.0'}
 
-  /@orama/orama@3.0.8:
-    resolution: {integrity: sha512-k4YX2iyIPbme0MKKaK22j77KX1woYkK7Zgz6QI4Buda+3mmzzk8/TlKLcKAYPgczTAjSWbH/OoqStfttMtKVLA==}
+  /@orama/orama@3.1.2:
+    resolution: {integrity: sha512-+A0VRkr8zSFg+cRfu1VyduuPrWWQeUunxZCi5JvBU4JpLx1/qZoWhplXCjGed5GJnL0nPrHXkBDG40Vb2zKOBQ==}
     engines: {node: '>= 16.0.0'}
     dev: false
 
@@ -7544,13 +7544,13 @@ packages:
       - postcss
     dev: false
 
-  /@orama/switch@3.0.7(@orama/orama@3.0.8)(@oramacloud/client@2.1.4):
+  /@orama/switch@3.0.7(@orama/orama@3.1.2)(@oramacloud/client@2.1.4):
     resolution: {integrity: sha512-AMDtn3ltgZ7Uyjz/FbISijTS7D3MWpD7v6zMM1wtLY1eUpur4RGNQDqc+K0tefN2xCZv4f0fq1PzhCG02HpdgA==}
     peerDependencies:
       '@orama/orama': 3.0.7
       '@oramacloud/client': ^2.1.1
     dependencies:
-      '@orama/orama': 3.0.8
+      '@orama/orama': 3.1.2
       '@oramacloud/client': 2.1.4
     dev: false
 
@@ -7580,8 +7580,8 @@ packages:
     resolution: {integrity: sha512-8UsuX+xqzyIKpNDCwlOh0/4q9psXKnM66Bmsejs9sYyBBJhP+h6h1fuhTIp6L66zXMMoiGjXHNb8cdW4j3ziBA==}
     dependencies:
       '@orama/highlight': 0.1.8
-      '@orama/orama': 3.0.8
-      '@orama/switch': 3.0.7(@orama/orama@3.0.8)(@oramacloud/client@2.1.4)
+      '@orama/orama': 3.1.2
+      '@orama/switch': 3.0.7(@orama/orama@3.1.2)(@oramacloud/client@2.1.4)
       '@oramacloud/client': 2.1.4
       '@phosphor-icons/webcomponents': 2.1.5
       '@stencil/core': 4.24.0
@@ -7658,7 +7658,7 @@ packages:
     resolution: {integrity: sha512-uNPFs4wq/iOPbggCwTkVNbIr64Vfd7ZS/h+cricXVnzXWocjDTfJ3wLL4lr0qiSu41g8z+eCAGBqJ30RO2O4AA==}
     dependencies:
       '@orama/cuid2': 2.2.3
-      '@orama/orama': 3.0.8
+      '@orama/orama': 3.1.2
       lodash: 4.17.21
     dev: false
 


### PR DESCRIPTION
Use _empty()_ to clean index before inserting chunks

This PR modifies the syncOramaIndex function to properly clean the index before inserting new chunks. By using the _empty()_ method and inserting only chunk instead of the entire docs array