### PR TITLE
Fix docusaurus dependencies to accept minor patch versions

### DIFF
--- a/packages/plugin-docusaurus-v3/package.json
+++ b/packages/plugin-docusaurus-v3/package.json
@@ -39,7 +39,7 @@
     "vfile-message": "^3.1.4"
   },
   "devDependencies": {
-    "@docusaurus/types": "~3.6.3",
+    "@docusaurus/types": "^3.6.3",
     "@types/jsdom": "^21.1.6",
     "@types/markdown-it": "^13.0.7",
     "@types/pako": "^2.0.3",
@@ -47,9 +47,9 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@docusaurus/plugin-content-docs": "~3.6.0",
-    "@docusaurus/theme-common": "~3.6.0",
-    "@docusaurus/utils": "~3.6.0",
+    "@docusaurus/plugin-content-docs": "^3.6.0",
+    "@docusaurus/theme-common": "^3.6.0",
+    "@docusaurus/utils": "^3.6.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },


### PR DESCRIPTION
As per title, allowing minor version dependencies of Docusaurus v3. Related to [Issue 907](https://github.com/oramasearch/orama/issues/907).