### PR TITLE
fix #911. Threshold 0 matches prefixes correctly

### DIFF
--- a/packages/orama/src/components/algorithms.ts
+++ b/packages/orama/src/components/algorithms.ts
@@ -41,8 +41,14 @@ export function prioritizeTokenScores(
   const results = tokenScores.sort((a, b) => b[1] - a[1])
 
   // If threshold is 1, it means we will return all the results with at least one search term,
-  // prioritizig the ones that contains more search terms (fuzzy match)
+  // prioritizing the ones that contains more search terms (fuzzy match)
   if (threshold === 1) {
+    return results
+  }
+
+  // For threshold = 0 when keywordsCount is 1 (single term search),
+  // we return all matches since they automatically contain 100% of keywords
+  if (threshold === 0 && keywordsCount === 1) {
     return results
   }
 
@@ -104,7 +110,7 @@ export function prioritizeTokenScores(
   const thresholdLength =
     lastTokenWithAllKeywords + Math.ceil((threshold * 100 * (allResults - lastTokenWithAllKeywords)) / 100)
 
-  return resultsWithIdAndScore.slice(0, allResults + thresholdLength)
+  return resultsWithIdAndScore.slice(0, Math.min(allResults, thresholdLength))
 }
 
 export function BM25(

--- a/packages/orama/tests/threshold.test.ts
+++ b/packages/orama/tests/threshold.test.ts
@@ -152,3 +152,53 @@ t.test('should return all the exact matches + X% of the partial matches', async 
   t.same(r1.count, 4)
   t.same(r2.count, 3)
 })
+
+// Related issue: https://github.com/oramasearch/orama/issues/911
+t.test('should return results for words with same root if threshold is 0', async (t) => {
+  const db = create({
+    schema: {
+      title: 'string'
+    }
+  })
+
+  await insert(db, { title: 'Phone, phonogram' })
+  await insert(db, { title: 'Bet, better' })
+  await insert(db, { title: 'Some random sentence' })
+  await insert(db, { title: 'The quick brown fox jumps over the lazy dog' })
+
+  const testCases: [string, number][] = [
+    ['p', 1],
+    ['ph', 1],
+    ['pho', 1],
+    ['phone', 1],
+    ['phono', 1],
+
+    ['b', 2],
+    ['be', 1],
+    ['bet', 1],
+    ['bett', 1],
+    ['bet hi', 0], // the term "hi" is not in any document, there should be no hits with threshold 0
+
+    ['s', 1],
+    ['r', 1],
+    ['se', 1],
+    ['so', 1],
+
+    ['some random se', 1],
+    ['some random stuff', 0],
+
+    ['the qui', 1],
+    ['the quick brown dog', 1]
+  ]
+
+  t.plan(testCases.length)
+
+  for (const [term, expectedCount] of testCases) {
+    const result = await search(db, { term, threshold: 0 })
+    t.same(
+      result.count,
+      expectedCount,
+      `Search term "${term}" with threshold 0 should match ${expectedCount} record(s), but matched ${result.count}`
+    )
+  }
+})


### PR DESCRIPTION
This pull request includes several changes to improve the search functionality and code readability in the `packages/orama/src/components` and `packages/orama/src/methods` directories. The most important changes include enhancements to the search algorithm, better handling of thresholds, and code formatting improvements.

### Enhancements to the search algorithm:
* [`packages/orama/src/components/algorithms.ts`](diffhunk://#diff-df9c6299f2508a6997f86839ad3011444128eebde7bd2ebf898e18ecad8dcb71L44-R54): Improved the `prioritizeTokenScores` function to handle single-term searches more effectively and corrected a typo in the comments. [[1]](diffhunk://#diff-df9c6299f2508a6997f86839ad3011444128eebde7bd2ebf898e18ecad8dcb71L44-R54) [[2]](diffhunk://#diff-df9c6299f2508a6997f86839ad3011444128eebde7bd2ebf898e18ecad8dcb71L107-R113)

### Better handling of thresholds:
* [`packages/orama/src/components/index.ts`](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L420-R446): Updated the `search` function to track tokens found during the search and ensure all tokens are found when the threshold is 0. This includes adding a new token tracking map and processing tokens more efficiently. [[1]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L420-R446) [[2]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L489-R476) [[3]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4R546-R581)
* [`packages/orama/src/methods/search-fulltext.ts`](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL53-R68): Adjusted the `innerFullTextSearch` function to handle default threshold values more robustly and improved the overall search process. [[1]](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL53-R68) [[2]](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL81-L95) [[3]](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL190-R200)

### Code formatting improvements:
* [`packages/orama/src/components/index.ts`](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L276-R285): Reformatted several functions for better readability, including `insert`, `insertVector`, `remove`, `searchByWhereClause`, `save`, `createIndex`, `addGeoResult`, and `addFindResult`. [[1]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L276-R285) [[2]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L289-R304) [[3]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L375-R401) [[4]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L659-R683) [[5]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L821-R843) [[6]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L869-R889) [[7]](diffhunk://#diff-99d64ab05cf2729c96d4fdf914e357dbc0e60c15ea9f5f2cfb8d4a7ca8b29dc4L886-R909)
* [`packages/orama/src/methods/search-fulltext.ts`](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL20-R26): Improved the formatting of the `innerFullTextSearch` and `fullTextSearch` functions for better readability. [[1]](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL20-R26) [[2]](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL53-R68) [[3]](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL81-L95) [[4]](diffhunk://#diff-3b5ae23360d856dad3a6ec019be9682cf3f86a3a37f26cfadc485d248d06685dL190-R200)

### Additional changes:
* [`packages/orama/src/trees/radix.ts`](diffhunk://#diff-0a81a5033e2159840deb1d340175b3174049271f7744023924a53dc3e5087865L270-R291): Enhanced the `RadixNode` class to handle prefix matches more effectively, ensuring terms like 'p' match 'phone'.
* [`packages/orama/tests/threshold.test.ts`](diffhunk://#diff-70f8ad468826981f820311cb72443251c0018920ea037dd0d1db85e2b4fb2b6fR155-R204): Added a new test case to verify that the search function returns results for words with the same root when the threshold is 0.