### PR TITLE
deps: Upgraded glob to 11.0.2 from 8.1.0.

### DIFF
--- a/packages/orama/package.json
+++ b/packages/orama/package.json
@@ -81,7 +81,9 @@
     }
   },
   "types": "./dist/commonjs/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/oramasearch/orama"
@@ -144,7 +146,6 @@
     "auto-changelog": "^2.4.0",
     "c8": "^7.12.0",
     "commitizen": "^4.2.6",
-    "glob": "^9.2.3",
     "prettier": "^2.8.1",
     "tap": "^21.0.1",
     "tap-mocha-reporter": "^5.0.3",
@@ -169,7 +170,10 @@
       "./components": "./src/components.ts",
       "./trees": "./src/trees.ts"
     },
-    "esmDialects": ["deno", "browser"]
+    "esmDialects": [
+      "deno",
+      "browser"
+    ]
   },
   "module": "./dist/esm/index.js"
 }

--- a/packages/plugin-parsedoc/package.json
+++ b/packages/plugin-parsedoc/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@orama/orama": "workspace:*",
-    "glob": "^8.1.0",
+    "glob": "^11.0.2",
     "hast-util-from-html": "^1.0.1",
     "hast-util-from-string": "^2.0.0",
     "hast-util-to-html": "^8.0.4",
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@swc/cli": "^0.1.59",
     "@swc/core": "^1.3.27",
-    "@types/glob": "^8.0.1",
     "@types/hast": "^2.3.4",
     "@types/node": "^20.9.0",
     "@types/tap": "^15.0.7",

--- a/packages/plugin-parsedoc/src/index.ts
+++ b/packages/plugin-parsedoc/src/index.ts
@@ -1,12 +1,11 @@
 import { AnyDocument, AnyOrama, insertMultiple } from '@orama/orama'
-import glob from 'glob'
+import { glob } from 'glob'
 import { Content, Element, Parent, Properties, Root } from 'hast'
 import { fromHtml } from 'hast-util-from-html'
 import { fromString } from 'hast-util-from-string'
 import { toHtml } from 'hast-util-to-html'
 import { toString } from 'hast-util-to-string'
 import { readFile } from 'node:fs/promises'
-import { promisify } from 'node:util'
 import { rehype } from 'rehype'
 import rehypeDocument from 'rehype-document'
 import rehypePresetMinify from 'rehype-preset-minify'
@@ -40,14 +39,13 @@ interface PopulateFromGlobOptions {
 type PopulateOptions = PopulateFromGlobOptions & { basePath?: string }
 
 type FileType = 'html' | 'md'
-const asyncGlob = promisify(glob)
 
 export async function populateFromGlob<T extends AnyOrama>(
   db: T,
   pattern: string,
   options?: PopulateFromGlobOptions
 ): Promise<void> {
-  const files = await asyncGlob(pattern)
+  const files = await glob(pattern)
   await Promise.all(files.map(async (filename) => populateFromFile(db, filename, options)))
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,9 +201,6 @@ importers:
       commitizen:
         specifier: ^4.2.6
         version: 4.3.1(@types/node@20.17.47)(typescript@5.8.3)
-      glob:
-        specifier: ^9.2.3
-        version: 9.3.5
       prettier:
         specifier: ^2.8.1
         version: 2.8.8
@@ -588,8 +585,8 @@ importers:
         specifier: workspace:*
         version: link:../orama
       glob:
-        specifier: ^8.1.0
-        version: 8.1.0
+        specifier: ^11.0.2
+        version: 11.0.2
       hast-util-from-html:
         specifier: ^1.0.1
         version: 1.0.2
@@ -630,9 +627,6 @@ importers:
       '@swc/core':
         specifier: ^1.3.27
         version: 1.11.24
-      '@types/glob':
-        specifier: ^8.0.1
-        version: 8.1.0
       '@types/hast':
         specifier: ^2.3.4
         version: 2.3.10
@@ -4706,9 +4700,6 @@ packages:
   '@types/express@4.17.21':
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
 
-  '@types/glob@8.1.0':
-    resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
-
   '@types/gtag.js@0.0.12':
     resolution: {integrity: sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==}
 
@@ -4783,9 +4774,6 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
-  '@types/minimatch@5.1.2':
-    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -7525,15 +7513,6 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
-  glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
-
-  glob@9.3.5:
-    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -9386,14 +9365,6 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
-
-  minimatch@8.0.4:
-    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -9437,10 +9408,6 @@ packages:
 
   minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@4.2.8:
-    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
     engines: {node: '>=8'}
 
   minipass@5.0.0:
@@ -19341,11 +19308,6 @@ snapshots:
       '@types/qs': 6.9.18
       '@types/serve-static': 1.15.7
 
-  '@types/glob@8.1.0':
-    dependencies:
-      '@types/minimatch': 5.1.2
-      '@types/node': 20.17.47
-
   '@types/gtag.js@0.0.12': {}
 
   '@types/hast@2.3.10':
@@ -19418,8 +19380,6 @@ snapshots:
   '@types/mdx@2.0.13': {}
 
   '@types/mime@1.3.5': {}
-
-  '@types/minimatch@5.1.2': {}
 
   '@types/minimist@1.2.5': {}
 
@@ -22959,21 +22919,6 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  glob@8.1.0:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.6
-      once: 1.4.0
-
-  glob@9.3.5:
-    dependencies:
-      fs.realpath: 1.0.0
-      minimatch: 8.0.4
-      minipass: 4.2.8
-      path-scurry: 1.11.1
-
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
@@ -25584,14 +25529,6 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
-  minimatch@5.1.6:
-    dependencies:
-      brace-expansion: 2.0.1
-
-  minimatch@8.0.4:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@9.0.3:
     dependencies:
       brace-expansion: 2.0.1
@@ -25642,8 +25579,6 @@ snapshots:
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
-
-  minipass@4.2.8: {}
 
   minipass@5.0.0: {}
 


### PR DESCRIPTION
Upgraded the `glob` dependency to 11.0.2 (latest) from a 2 year old _deprecated_ 8.1.0.
- It was only used by the `plugin-parsedoc` package, so removed the unnecessary `devDependency` declaration from the top-level `package.json`.
- The new version has types, making the additional `@types/glob` dependency unnecessary.
- Previously, two versions were mentioned (9.2.3 and 8.1.0), so this change removes any confusing inconsistency.