### PR TITLE
fix: search with `exact: true`

### DIFF
--- a/packages/orama/package.json
+++ b/packages/orama/package.json
@@ -81,7 +81,9 @@
     }
   },
   "types": "./dist/commonjs/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/oramasearch/orama"
@@ -169,7 +171,10 @@
       "./components": "./src/components.ts",
       "./trees": "./src/trees.ts"
     },
-    "esmDialects": ["deno", "browser"]
+    "esmDialects": [
+      "deno",
+      "browser"
+    ]
   },
   "module": "./dist/esm/index.js"
 }

--- a/packages/orama/src/components/index.ts
+++ b/packages/orama/src/components/index.ts
@@ -459,8 +459,8 @@ export function search(
   tokenizer: Tokenizer,
   language: string | undefined,
   propertiesToSearch: string[],
-  exact: boolean,
   tolerance: number,
+  exactToken: boolean,
   boost: Record<string, number>,
   relevance: Required<BM25Params>,
   docsCount: number,
@@ -500,7 +500,7 @@ export function search(
     const tokenLength = tokens.length
     for (let i = 0; i < tokenLength; i++) {
       const token = tokens[i]
-      const searchResult = tree.node.find({ term: token, exact, tolerance })
+      const searchResult = tree.node.find({ term: token, exact: exactToken, tolerance })
 
       // See if this token was found (for threshold=0 filtering)
       const termsFound = Object.keys(searchResult)

--- a/packages/orama/src/package.json
+++ b/packages/orama/src/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/packages/orama/src/types.ts
+++ b/packages/orama/src/types.ts
@@ -319,6 +319,11 @@ export interface SearchParamsFullText<T extends AnyOrama, ResultDocument = Typed
   exact?: boolean
 
   /**
+   * Whether each token should be matched exactly.
+   */
+  exactToken?: boolean
+
+  /**
    * The maximum [levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
    * between the term and the searchable property.
    */
@@ -982,8 +987,8 @@ export interface IIndex<I extends AnyIndexStore> {
     tokenizer: Tokenizer,
     language: string | undefined,
     propertiesToSearch: string[],
-    exact: boolean,
     tolerance: number,
+    exactToken: boolean,
     boost: Partial<Record<OnlyStrings<FlattenSchemaProperty<T>[]>, number>>,
     relevance: Required<BM25Params>,
     docsCount: number,

--- a/packages/orama/tests/dataset.test.ts
+++ b/packages/orama/tests/dataset.test.ts
@@ -108,9 +108,9 @@ t.test("orama.dataset", async (t) => {
       Object.keys((db.data.docs as DocumentsStore).docs).length,
       (dataset as EventJson).result.events.length,
     );
-    t.equal(s1.count, 1117);
-    t.equal(s2.count, 7314);
-    t.equal(s3.count, 7314);
+    t.equal(s1.count, 1081);
+    t.equal(s2.count, 0);
+    t.equal(s3.count, 1842);
 
     t.end();
   });
@@ -143,7 +143,7 @@ t.test("orama.dataset", async (t) => {
     const s1 = removeVariadicData(
       await search(db, {
         term: "war",
-        exact: true,
+        exactToken: true,
         // eslint-disable-next-line
         // @ts-ignore
         properties: ["description"],
@@ -155,7 +155,7 @@ t.test("orama.dataset", async (t) => {
     const s2 = removeVariadicData(
       await search(db, {
         term: "war",
-        exact: true,
+        exactToken: true,
         properties: ["description"],
         limit: 10,
         offset: 10,
@@ -165,7 +165,7 @@ t.test("orama.dataset", async (t) => {
     const s3 = removeVariadicData(
       await search(db, {
         term: "war",
-        exact: true,
+        exactToken: true,
         properties: ["description"],
         limit: 10,
         offset: 20,
@@ -174,7 +174,7 @@ t.test("orama.dataset", async (t) => {
 
     const s4 = await search(db, {
       term: "war",
-      exact: true,
+      exactToken: true,
       properties: ["description"],
       limit: 2240,
       offset: 0,
@@ -182,7 +182,7 @@ t.test("orama.dataset", async (t) => {
 
     const s5 = await search(db, {
       term: "war",
-      exact: true,
+      exactToken: true,
       properties: ["description"],
       limit: 10,
       offset: 2239,
@@ -223,7 +223,7 @@ t.test("orama.dataset", async (t) => {
   t.test("should correctly delete documents", async (t) => {
     const documentsToDelete = await search(db, {
       term: "war",
-      exact: true,
+      exactToken: true,
       properties: ["description"],
       limit: 10,
       offset: 0,
@@ -235,13 +235,12 @@ t.test("orama.dataset", async (t) => {
 
     const newSearch = await search(db, {
       term: "war",
-      exact: true,
       properties: ["description"],
       limit: 10,
       offset: 0,
     });
 
-    t.equal(newSearch.count, 2347);
+    t.equal(newSearch.count, 2743);
 
     t.end();
   });

--- a/packages/orama/tests/search.test.ts
+++ b/packages/orama/tests/search.test.ts
@@ -84,11 +84,11 @@ t.test('search method', async (t) => {
       await insert(db, { quote: 'I like cats. They are the best.', author: 'Jane Doe' })
 
       // Exact search
-      const result1 = await search(db, { term: 'fox', exact: true })
+      const result1 = await search(db, { term: 'John Doe', properties: ["author"], exact: true })
       const result2 = await search(db, { term: 'dog', exact: true })
 
       t.equal(result1.count, 2)
-      t.equal(result2.count, 3)
+      t.equal(result2.count, 0)
 
       // Prefix search
       const result3 = await search(db, { term: 'fox', exact: false })
@@ -193,7 +193,7 @@ t.test('search method', async (t) => {
 
       const partialSearch = await search(db, {
         term: 'alr',
-        exact: true
+        exactToken: true
       })
 
       t.equal(partialSearch.count, 0)
@@ -201,7 +201,7 @@ t.test('search method', async (t) => {
 
       const exactSearch = await search(db, {
         term: 'already',
-        exact: true
+        exactToken: true
       })
 
       t.equal(exactSearch.count, 1)
@@ -719,11 +719,11 @@ t.test('search method', async (t) => {
 
     const result1 = await search(db, { term: 'foxes', exact: true })
     const result2 = await search(db, { term: 'cats', exact: true })
-    const result3 = await search(db, { term: 'brown', exact: true })
+    const result3 = await search(db, { term: 'John Doe', exact: true })
 
     t.equal(result1.count, 0)
     t.equal(result2.count, 0)
-    t.equal(result3.count, 1)
+    t.equal(result3.count, 2)
     t.end()
   })
 

--- a/packages/plugin-pt15/src/index.ts
+++ b/packages/plugin-pt15/src/index.ts
@@ -110,11 +110,11 @@ function createComponents(schema: AnySchema): Partial<ObjectComponents<any, any,
       removeDocumentScoreParameters: () => {throw new Error()},
       removeTokenScoreParameters: () => {throw new Error()},
       calculateResultScores: () => {throw new Error()},
-      search: function search<T extends AnyOrama>(index: PT15IndexStore, term: string, tokenizer: Tokenizer, language: string | undefined, propertiesToSearch: string[], exact: boolean, tolerance: number, boost: Partial<Record<OnlyStrings<FlattenSchemaProperty<T>[]>, number>>, relevance: Required<BM25Params>, docsCount: number, whereFiltersIDs: Set<InternalDocumentID> | undefined): TokenScore[] {
+      search: function search<T extends AnyOrama>(index: PT15IndexStore, term: string, tokenizer: Tokenizer, language: string | undefined, propertiesToSearch: string[], tolerance: number, exactToken: boolean, boost: Partial<Record<OnlyStrings<FlattenSchemaProperty<T>[]>, number>>, relevance: Required<BM25Params>, docsCount: number, whereFiltersIDs: Set<InternalDocumentID> | undefined): TokenScore[] {
         if (tolerance !== 0) {
           throw new Error('Tolerance not implemented yet')
         }
-        if (exact === true) {
+        if (exactToken === true) {
           throw new Error('Exact not implemented yet')
         }
 

--- a/packages/tokenizers/package.json
+++ b/packages/tokenizers/package.json
@@ -30,7 +30,9 @@
   "dependencies": {
     "@orama/orama": "workspace:*"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/oramasearch/orama"
@@ -65,7 +67,10 @@
     "node": ">= 20.0.0"
   },
   "tshy": {
-    "dialects": ["esm", "commonjs"],
+    "dialects": [
+      "esm",
+      "commonjs"
+    ],
     "exports": {
       "./japanese": "./src/japanese.ts",
       "./mandarin": "./src/mandarin.ts",


### PR DESCRIPTION
### 🔗 Linked Issue
Closes #866

### ❓ Type of Change
<!-- Tick all that apply -->
- [ ] 📖 Documentation (updates to docs or README)
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improves existing functionality)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🧹 Chore (build process or auxiliary tooling)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behaviour)

### 📚 Description
With `exact: true`, the search currently returns documents whose terms **partially** match the query instead of only those with an **exact** match.

**Why it happens**

1. The search code first [tokenises](https://github.com/oramasearch/orama/blob/3717f0592d9bf0cee514cbc737f93afe3ffbef1d/packages/orama/src/components/index.ts#L470) the `term`.  
2. For each token, it then [checks the radix tree for that same token](https://github.com/oramasearch/orama/blob/3717f0592d9bf0cee514cbc737f93afe3ffbef1d/packages/orama/src/components/index.ts#L503).  

Unfortunetly, neither `filters` nor `facets` allow a strict equality between a property value and the full term. Below my proposal.

### 🛠️ Proposed Solution
1. Keep the current token-level matching.  
2. Rename the internal `exact` flag to something explicit (e.g. `exactToken`; open to suggestions).  
3. Apply the **public** `exact` option only when comparing the *entire* property value to the *entire* normalised term. (like implemented in this PR)

### ✅ Status
- [x] Implementation complete  
- [x] Tests updated  
- [ ] Documentation updated  

@algora-pbc /claim #866 