### PR TITLE
Update multi-index-search.mdx

### DIFF
--- a/packages/docs/src/content/docs/cloud/performing-search/multi-index-search.mdx
+++ b/packages/docs/src/content/docs/cloud/performing-search/multi-index-search.mdx
@@ -79,7 +79,7 @@ The client exposes a simple `search` method that can be used to query the index.
     ```
 
 <Aside type="caution" title="Limitations">
-  Due to the nature of multi index search grouping (`groupBy`) is not supported. 
+  Due to the nature of multi index search grouping (`groupBy`) as well as the "where" property for filter purposes are not supported. 
 </Aside>
 
 


### PR DESCRIPTION
mentioned the fact that for multi search the "where" clause is not supported