### PR TITLE
Update stopwords docs URL

### DIFF
--- a/packages/stopwords/README.md
+++ b/packages/stopwords/README.md
@@ -46,7 +46,7 @@ const db = create({
 })
 ```
 
-Read more in the official docs: [https://docs.orama.com/docs/orama-js/text-analysis/stopwords](https://docs.orama.com/docs/orama-js/text-analysis/stopwords).
+Read more in the official docs: [https://docs.orama.com/docs/orama-js/text-analysis/stop-words](https://docs.orama.com/docs/orama-js/text-analysis/stop-words).
 
 # License
 


### PR DESCRIPTION
The current one is https://docs.orama.com/docs/orama-js/text-analysis/stop-words