### PR TITLE
fix: version name

### DIFF
--- a/packages/plugin-docusaurus-v3/src/theme/SearchBar/index.tsx
+++ b/packages/plugin-docusaurus-v3/src/theme/SearchBar/index.tsx
@@ -72,6 +72,18 @@ export function OramaSearchNoDocs() {
   )
 }
 
+function getVersionName(version: string | { name: string } | null): string | undefined {
+  if (!version) {
+    return undefined
+  }
+
+  if (typeof version === 'string') {
+    return version
+  }
+
+  return version.name
+}
+
 export function OramaSearchWithDocs({ pluginId }: { pluginId: string }) {
   const colorMode = getColorMode()
   const { searchBoxConfig, searchBtnConfig } = useOrama()
@@ -79,7 +91,7 @@ export function OramaSearchWithDocs({ pluginId }: { pluginId: string }) {
   const versions = useVersions(pluginId)
   const activeVersion = useActiveVersion(pluginId)
   const preferredVersion = getPreferredVersion(searchBoxConfig.basic.clientInstance)
-  const currentVersion = activeVersion || preferredVersion || versions[0]
+  const currentVersion = getVersionName(activeVersion) || getVersionName(preferredVersion) || getVersionName(versions[0]);
 
   const searchParams = {
     ...(currentVersion && {


### PR DESCRIPTION
Considering [this issue](https://github.com/fastify/website/pull/361), Orama's plugin doesn't seems to work on the fastify's website.
Thanks to the patch proposed in this PR, made by @smith558, we would like to fix this behaviour.