### PR TITLE
fix(orama): break the search circular dependency behind Metro/Expo failure (#961)

### DIFF
--- a/packages/orama/src/methods/fetch-documents.ts
+++ b/packages/orama/src/methods/fetch-documents.ts
@@ -1,0 +1,99 @@
+import { InternalDocumentID, getDocumentIdFromInternalId } from '../components/internal-document-id-store.js'
+import { getNested } from '../utils.js'
+import type { AnyOrama, LiteralUnion, Result, SearchableValue, TypedDocument } from '../types.js'
+
+export function fetchDocumentsWithDistinct<T extends AnyOrama, ResultDocument extends TypedDocument<T>>(
+  orama: T,
+  uniqueDocsArray: [InternalDocumentID, number][],
+  offset: number,
+  limit: number,
+  distinctOn: LiteralUnion<T['schema']>
+): Result<ResultDocument>[] {
+  const docs = orama.data.docs
+
+  // Keep track which values we already seen
+  const values = new Map<SearchableValue, true>()
+
+  // We cannot know how many results we will have in the end,
+  // so we need cannot pre-allocate the array.
+  const results: Result<ResultDocument>[] = []
+
+  const resultIDs: Set<InternalDocumentID> = new Set()
+  const uniqueDocsArrayLength = uniqueDocsArray.length
+  let count = 0
+  for (let i = 0; i < uniqueDocsArrayLength; i++) {
+    const idAndScore = uniqueDocsArray[i]
+
+    // If there are no more results, just break the loop
+    if (typeof idAndScore === 'undefined') {
+      continue
+    }
+
+    const [id, score] = idAndScore
+
+    if (resultIDs.has(id)) {
+      continue
+    }
+
+    const doc = orama.documentsStore.get(docs, id)
+    const value = getNested(doc as object, distinctOn)
+    if (typeof value === 'undefined' || values.has(value)) {
+      continue
+    }
+    values.set(value, true)
+
+    count++
+    // We shouldn't consider the document if it's not in the offset range
+    if (count <= offset) {
+      continue
+    }
+
+    results.push({ id: getDocumentIdFromInternalId(orama.internalDocumentIDStore, id), score, document: doc! })
+    resultIDs.add(id)
+
+    // reached the limit, break the loop
+    if (count >= offset + limit) {
+      break
+    }
+  }
+
+  return results
+}
+
+export function fetchDocuments<T extends AnyOrama, ResultDocument extends TypedDocument<T>>(
+  orama: T,
+  uniqueDocsArray: [InternalDocumentID, number][],
+  offset: number,
+  limit: number
+): Result<ResultDocument>[] {
+  const docs = orama.data.docs
+
+  const results: Result<ResultDocument>[] = Array.from({
+    length: limit
+  })
+
+  const resultIDs: Set<InternalDocumentID> = new Set()
+
+  // We already have the list of ALL the document IDs containing the search terms.
+  // We loop over them starting from a positional value "offset" and ending at "offset + limit"
+  // to provide pagination capabilities to the search.
+  for (let i = offset; i < limit + offset; i++) {
+    const idAndScore = uniqueDocsArray[i]
+
+    // If there are no more results, just break the loop
+    if (typeof idAndScore === 'undefined') {
+      break
+    }
+
+    const [id, score] = idAndScore
+
+    if (!resultIDs.has(id)) {
+      // We retrieve the full document only AFTER making sure that we really want it.
+      // We never retrieve the full document preventively.
+      const fullDoc = orama.documentsStore.get(docs, id)
+      results[i] = { id: getDocumentIdFromInternalId(orama.internalDocumentIDStore, id), score, document: fullDoc! }
+      resultIDs.add(id)
+    }
+  }
+  return results
+}

--- a/packages/orama/src/methods/search-fulltext.ts
+++ b/packages/orama/src/methods/search-fulltext.ts
@@ -18,7 +18,7 @@ import type {
 } from '../types.js'
 import { getNanosecondsTime, removeVectorsFromHits, sortTokenScorePredicate } from '../utils.js'
 import { count } from './docs.js'
-import { fetchDocuments, fetchDocumentsWithDistinct } from './search.js'
+import { fetchDocuments, fetchDocumentsWithDistinct } from './fetch-documents.js'
 
 export function innerFullTextSearch<T extends AnyOrama>(
   orama: T,

--- a/packages/orama/src/methods/search-hybrid.ts
+++ b/packages/orama/src/methods/search-hybrid.ts
@@ -10,7 +10,7 @@ import type {
 import { getNanosecondsTime, formatNanoseconds, removeVectorsFromHits } from '../utils.js'
 import { getFacets } from '../components/facets.js'
 import { getGroups } from '../components/groups.js'
-import { fetchDocuments } from './search.js'
+import { fetchDocuments } from './fetch-documents.js'
 import { innerFullTextSearch } from './search-fulltext.js'
 import { innerVectorSearch } from './search-vector.js'
 import { runAfterSearch, runBeforeSearch } from '../components/hooks.js'

--- a/packages/orama/src/methods/search.ts
+++ b/packages/orama/src/methods/search.ts
@@ -1,16 +1,11 @@
-import { InternalDocumentID, getDocumentIdFromInternalId } from '../components/internal-document-id-store.js'
 import { createError } from '../errors.js'
-import { getNested } from '../utils.js'
 import type {
   AnyOrama,
-  LiteralUnion,
-  Result,
   Results,
   SearchParams,
   SearchParamsFullText,
   SearchParamsHybrid,
   SearchParamsVector,
-  SearchableValue,
   TypedDocument
 } from '../types.js'
 import { MODE_FULLTEXT_SEARCH, MODE_HYBRID_SEARCH, MODE_VECTOR_SEARCH } from '../constants.js'
@@ -38,100 +33,4 @@ export function search<T extends AnyOrama, ResultDocument = TypedDocument<T>>(
   }
 
   throw createError('INVALID_SEARCH_MODE', mode)
-}
-
-export function fetchDocumentsWithDistinct<T extends AnyOrama, ResultDocument extends TypedDocument<T>>(
-  orama: T,
-  uniqueDocsArray: [InternalDocumentID, number][],
-  offset: number,
-  limit: number,
-  distinctOn: LiteralUnion<T['schema']>
-): Result<ResultDocument>[] {
-  const docs = orama.data.docs
-
-  // Keep track which values we already seen
-  const values = new Map<SearchableValue, true>()
-
-  // We cannot know how many results we will have in the end,
-  // so we need cannot pre-allocate the array.
-  const results: Result<ResultDocument>[] = []
-
-  const resultIDs: Set<InternalDocumentID> = new Set()
-  const uniqueDocsArrayLength = uniqueDocsArray.length
-  let count = 0
-  for (let i = 0; i < uniqueDocsArrayLength; i++) {
-    const idAndScore = uniqueDocsArray[i]
-
-    // If there are no more results, just break the loop
-    if (typeof idAndScore === 'undefined') {
-      continue
-    }
-
-    const [id, score] = idAndScore
-
-    if (resultIDs.has(id)) {
-      continue
-    }
-
-    const doc = orama.documentsStore.get(docs, id)
-    const value = getNested(doc as object, distinctOn)
-    if (typeof value === 'undefined' || values.has(value)) {
-      continue
-    }
-    values.set(value, true)
-
-    count++
-    // We shouldn't consider the document if it's not in the offset range
-    if (count <= offset) {
-      continue
-    }
-
-    results.push({ id: getDocumentIdFromInternalId(orama.internalDocumentIDStore, id), score, document: doc! })
-    resultIDs.add(id)
-
-    // reached the limit, break the loop
-    if (count >= offset + limit) {
-      break
-    }
-  }
-
-  return results
-}
-
-export function fetchDocuments<T extends AnyOrama, ResultDocument extends TypedDocument<T>>(
-  orama: T,
-  uniqueDocsArray: [InternalDocumentID, number][],
-  offset: number,
-  limit: number
-): Result<ResultDocument>[] {
-  const docs = orama.data.docs
-
-  const results: Result<ResultDocument>[] = Array.from({
-    length: limit
-  })
-
-  const resultIDs: Set<InternalDocumentID> = new Set()
-
-  // We already have the list of ALL the document IDs containing the search terms.
-  // We loop over them starting from a positional value "offset" and ending at "offset + limit"
-  // to provide pagination capabilities to the search.
-  for (let i = offset; i < limit + offset; i++) {
-    const idAndScore = uniqueDocsArray[i]
-
-    // If there are no more results, just break the loop
-    if (typeof idAndScore === 'undefined') {
-      break
-    }
-
-    const [id, score] = idAndScore
-
-    if (!resultIDs.has(id)) {
-      // We retrieve the full document only AFTER making sure that we really want it.
-      // We never retrieve the full document preventively.
-      const fullDoc = orama.documentsStore.get(docs, id)
-      results[i] = { id: getDocumentIdFromInternalId(orama.internalDocumentIDStore, id), score, document: fullDoc! }
-      resultIDs.add(id)
-    }
-  }
-  return results
 }


### PR DESCRIPTION
## Summary

Root-cause fix for #961 (`fetchDocuments is not a function` under Metro/Expo). Supersedes #963, which worked around the same cycle by shipping an esbuild-bundled artifact.

## The bug

`methods/search.ts` was overloaded — it held **both**:
- the `search()` dispatcher, which imports `fullTextSearch` / `searchVector` / `hybridSearch`, and
- the `fetchDocuments` / `fetchDocumentsWithDistinct` helpers, which those same per-mode modules import back.

That mutual import (`search.ts ⇄ search-fulltext.ts`, `search.ts ⇄ search-hybrid.ts`) is a circular dependency. It's harmless under Node and most bundlers, but **fatal under Metro/Expo with `experimentalImportSupport`** (the new tree-shaking), where the binding is read before initialization → `fetchDocuments is not a function`.

## The fix

Move the two pure helpers into a new `methods/fetch-documents.ts` (they depend only on `internal-document-id-store` + `getNested` — no back-edge), and import them from there in `search-fulltext.ts` / `search-hybrid.ts`. `search.ts` keeps only the dispatcher.

- `search-fulltext` / `search-hybrid` no longer import `search.ts` → the cycle is gone.
- Fixes it for **every** bundler, not just Metro — no opt-in `bundle` export condition, no second artifact, no esbuild added to the build.
- It also sidesteps the maintainer's stated reason for not bundling (ESM↔CJS pain, noted in #961) — this is a pure source move, no bundler involved.

## Why this instead of #963

#963 (the maintainer's own suggestion) fixes the symptom by adding a `bundle` export condition + an esbuild `postbuild` that ships pre-bundled `dist/bundle/*`. It works, but: consumers must configure their resolver to prefer the `bundle` condition, it ships a parallel minified copy of the library, adds esbuild to the core build, and masks cycles rather than removing them. This PR removes the cycle at the source instead.

## Validation

- `pnpm build` — 18/18 packages green.
- `pnpm --filter @orama/orama test` — **1326 pass / 0 fail / 3 skip** (40/40 suites). Pure code move, no behavior change.
- Public API unchanged — `fetchDocuments`/`fetchDocumentsWithDistinct` were never exported (only `search` is).

## Verification still needed

This removes the **specific** cycle behind the reported error. @isaachinman — you have the Metro/Expo repro (`orama-require-cycle-reproduction`) and kindly offered to verify; could you confirm `bun run web` is clean against this branch? If Metro surfaces a *second* cycle once this one's gone, I'll extract that too. Keeping #963 open as a fallback until the repro confirms.

Addresses #961.
